### PR TITLE
Reducing usage of calculated field

### DIFF
--- a/lib/models/transaction.js
+++ b/lib/models/transaction.js
@@ -57,7 +57,7 @@ TransactionSchema.statics.batchImport = async function (params) {
 TransactionSchema.statics.addTransactions = async function(params){
   let { blockHash, blockTime, blockTimeNormalized, chain, height, network, txs } = params;
   return new Promise(async (resolve, reject) => {
-    let txids = txs.map((tx) => tx.hash);
+    let txids = txs.map((tx) => tx._hash);
     let mintWallets, spentWallets;
     try {
       mintWallets = await Coin.collection.aggregate([
@@ -127,7 +127,8 @@ TransactionSchema.statics.mintCoins = async function (params) {
       parentChainCoins = await Coin.find({ chain: parentChain, network, mintHeight: height, spentHeight: {$gt: -2, $lt: forkHeight} }).lean();
     }
     for (let tx of txs) {
-      let txid = tx.hash;
+      tx._hash = tx.hash;
+      let txid = tx._hash;
       let isCoinbase = tx.isCoinbase();
       for (let [index, output] of tx.outputs.entries()) {
         let parentChainCoin = parentChainCoins.find((parentChainCoin) => parentChainCoin.mintTxid === txid && parentChainCoin.mintIndex === index);
@@ -198,7 +199,7 @@ TransactionSchema.statics.spendCoins = function (params) {
     if (tx.isCoinbase()) {
       continue;
     }
-    let txid = tx.hash;
+    let txid = tx._hash;
     for (let input of tx.inputs) {
       input = input.toObject();
       spendOps.push({


### PR DESCRIPTION
if tx.hash is a calculated property, we should cache it as tx._hash the first time we get it, and then reference that everywhere.