### PR TITLE
Chain state provider + Currency Routes + Tests

### DIFF
--- a/lib/models/block.js
+++ b/lib/models/block.js
@@ -32,9 +32,6 @@ BlockSchema.index({ chain: 1, network: 1, previousBlockHash: 1});
 
 BlockSchema.statics.addBlock = function(params, callback){
   let {block, chain, network, parentChain, forkHeight} = params;
-  if(block === undefined) {
-    return callback(new Error('Block is undefined'));
-  }
   let header = block.header.toObject();
   let blockTime = header.time * 1000;
   let blockTimeNormalized;

--- a/lib/models/block.js
+++ b/lib/models/block.js
@@ -32,6 +32,9 @@ BlockSchema.index({ chain: 1, network: 1, previousBlockHash: 1});
 
 BlockSchema.statics.addBlock = function(params, callback){
   let {block, chain, network, parentChain, forkHeight} = params;
+  if(block === undefined) {
+    return callback(new Error('Block is undefined'));
+  }
   let header = block.header.toObject();
   let blockTime = header.time * 1000;
   let blockTimeNormalized;

--- a/lib/models/coin.js
+++ b/lib/models/coin.js
@@ -11,22 +11,25 @@ const Coin = new Schema({
   value: Number,
   address: String,
   script: Buffer,
-  wallets: {type: [Schema.Types.ObjectId]},
+  wallets: { type: [Schema.Types.ObjectId] },
   spentTxid: String,
   spentHeight: Number
 });
 
-Coin.index({ chain: 1, network: 1, mintTxid: 1 });
-Coin.index({ chain: 1, network: 1, mintTxid: 1, mintIndex: 1 }, {partialFilterExpression: {spentHeight: {$lt: 0}}});
-Coin.index({ chain: 1, network: 1, address: 1 });
-Coin.index({ chain: 1, network: 1, mintHeight: 1 });
-Coin.index({ chain: 1, network: 1, spentTxid: 1 }, { sparse: true });
-Coin.index({ chain: 1, network: 1, spentHeight: 1 });
+Coin.index({ mintTxid: 1, chain: 1, network: 1 });
+Coin.index(
+  { mintTxid: 1, mintIndex: 1, chain: 1, network: 1 },
+  { partialFilterExpression: { spentHeight: { $lt: 0 } } }
+);
+Coin.index({ address: 1, chain: 1, network: 1 });
+Coin.index({ mintHeight: 1, chain: 1, network: 1 });
+Coin.index({ spentTxid: 1, chain: 1, network: 1 }, { sparse: true });
+Coin.index({ spentHeight: 1, chain: 1, network: 1 });
 Coin.index({ wallets: 1, spentHeight: 1 }, { sparse: true });
 
-Coin.statics.getBalance = function(params){
-  let {query} = params;
-  query = Object.assign(query, { spentHeight: { $lt: 0 }});
+Coin.statics.getBalance = function(params) {
+  let { query } = params;
+  query = Object.assign(query, { spentHeight: { $lt: 0 } });
   return this.aggregate([
     { $match: query },
     {
@@ -39,7 +42,7 @@ Coin.statics.getBalance = function(params){
   ]);
 };
 
-Coin.statics._apiTransform = function (coin, options) {
+Coin.statics._apiTransform = function(coin, options) {
   let script = coin.script || '';
   let transform = {
     txid: coin.mintTxid,

--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -1,0 +1,6 @@
+require('../models/coin');
+require('../models/walletAddress');
+require('../models/transaction');
+require('../models/wallet');
+require('../models/block');
+

--- a/lib/models/wallet.js
+++ b/lib/models/wallet.js
@@ -12,7 +12,8 @@ const WalletSchema = new Schema({
 
 WalletSchema.statics._apiTransform = function (wallet, options) {
   let transform = {
-    name: wallet.name
+    name: wallet.name,
+    pubKey: wallet.pubKey
   };
   if (options && options.object) {
     return transform;

--- a/lib/providers/chain-state/bch/bch.js
+++ b/lib/providers/chain-state/bch/bch.js
@@ -1,0 +1,9 @@
+const BTCStateProvider = require('../btc/btc');
+const util = require('util');
+
+function BCHStateProvider(chain) {
+  this.chain = chain.toUpperCase() || 'BCH';
+}
+util.inherits(BCHStateProvider, BTCStateProvider);
+
+module.exports = BCHStateProvider;

--- a/lib/providers/chain-state/bch/bch.js
+++ b/lib/providers/chain-state/bch/bch.js
@@ -1,8 +1,8 @@
 const BTCStateProvider = require('../btc/btc');
 const util = require('util');
 
-function BCHStateProvider(chain) {
-  this.chain = chain.toUpperCase() || 'BCH';
+function BCHStateProvider() {
+  BTCStateProvider.call(this, 'BCH');
 }
 util.inherits(BCHStateProvider, BTCStateProvider);
 

--- a/lib/providers/chain-state/btc/btc.js
+++ b/lib/providers/chain-state/btc/btc.js
@@ -51,7 +51,7 @@ BTCStateProvider.prototype.getBlock = async function(network, blockId){
     }
     query.height = height;
   }
-  let block = await Block.find(query).exec();
+  let block = await Block.findOne(query).exec();
   if(!block) {
     throw 'block not found';
   }

--- a/lib/providers/chain-state/btc/btc.js
+++ b/lib/providers/chain-state/btc/btc.js
@@ -1,5 +1,4 @@
 const JSONStream = require('JSONStream');
-const ListTransactionsStream = require('./transforms');
 const Storage = require('../../../services/storage');
 const mongoose = require('mongoose');
 const Wallet = mongoose.model('Wallet');
@@ -111,7 +110,7 @@ BTCStateProvider.prototype.updateWallet = async function(network, walletId, addr
 
 BTCStateProvider.prototype.getWalletTransactions = async function(network, walletId, stream, args) {
   let query = {
-    wallets: walletId
+    wallets: mongoose.Types.ObjectId(walletId)
   };
   if(args) {
     if (args.startBlock) {
@@ -129,9 +128,7 @@ BTCStateProvider.prototype.getWalletTransactions = async function(network, walle
       query.blockTimeNormalized.$lt = new Date(args.endDate);
     }
   }
-  let transactionStream = Transaction.getTransactions({query});
-  let listTransactionsStream = new ListTransactionsStream(walletId);
-  transactionStream.pipe(listTransactionsStream).pipe(stream);
+  Storage.apiStreamingFind(Transaction, query, stream);
 };
 
 BTCStateProvider.prototype.getWalletBalance = async function(walletId) {

--- a/lib/providers/chain-state/btc/btc.js
+++ b/lib/providers/chain-state/btc/btc.js
@@ -1,4 +1,5 @@
 const JSONStream = require('JSONStream');
+const ListTransactionsStream = require('./transforms');
 const Storage = require('../../../services/storage');
 const mongoose = require('mongoose');
 const Wallet = mongoose.model('Wallet');
@@ -128,7 +129,9 @@ BTCStateProvider.prototype.getWalletTransactions = async function(network, walle
       query.blockTimeNormalized.$lt = new Date(args.endDate);
     }
   }
-  Storage.apiStreamingFind(Transaction, query, stream);
+  let transactionStream = Transaction.getTransactions({query});
+  let listTransactionsStream = new ListTransactionsStream(walletId);
+  transactionStream.pipe(listTransactionsStream).pipe(stream);
 };
 
 BTCStateProvider.prototype.getWalletBalance = async function(walletId) {

--- a/lib/providers/chain-state/btc/btc.js
+++ b/lib/providers/chain-state/btc/btc.js
@@ -110,8 +110,11 @@ BTCStateProvider.prototype.updateWallet = async function(network, walletId, addr
 };
 
 BTCStateProvider.prototype.getWalletTransactions = async function(network, walletId, stream, args) {
+  let wallet = await Wallet.findOne({ _id: walletId }).exec();
   let query = {
-    wallets: mongoose.Types.ObjectId(walletId)
+    chain: this.chain,
+    network,
+    wallets: wallet._id
   };
   if(args) {
     if (args.startBlock) {
@@ -130,7 +133,7 @@ BTCStateProvider.prototype.getWalletTransactions = async function(network, walle
     }
   }
   let transactionStream = Transaction.getTransactions({query});
-  let listTransactionsStream = new ListTransactionsStream(walletId);
+  let listTransactionsStream = new ListTransactionsStream(wallet._id);
   transactionStream.pipe(listTransactionsStream).pipe(stream);
 };
 

--- a/lib/providers/chain-state/btc/btc.js
+++ b/lib/providers/chain-state/btc/btc.js
@@ -1,6 +1,6 @@
 const JSONStream = require('JSONStream');
 const ListTransactionsStream = require('./transforms');
-const Storage = require('../../services/storage');
+const Storage = require('../../../services/storage');
 const mongoose = require('mongoose');
 const Wallet = mongoose.model('Wallet');
 const WalletAddress = mongoose.model('WalletAddress');
@@ -8,9 +8,25 @@ const Transaction = mongoose.model('Transaction');
 const Coin = mongoose.model('Coin');
 const Block = mongoose.model('Coin');
 
-function BTCStateProvider(chain) {
-  this.chain = chain.toUpperCase() || 'BTC';
-}
+function BTCStateProvider(){}
+
+BTCStateProvider.prototype = (chain)=> {
+  this.chain = chain || 'BTC';
+  this.chain = this.chain.toUpperCase();
+};
+
+BTCStateProvider.prototype.getAddressUtxos = async(network, address, stream, args) => {
+  if (typeof address !== 'string' || !this.chain || !network) {
+    throw 'Missing required param';
+  }
+  network = network.toLowerCase();
+  let query = {chain: this.chain, network, address};
+  const unspent = args.unspent;
+  if (unspent) {
+    query.spentHeight = { $lt: 0 };
+  }
+  Storage.apiStreamingFind(Coin, query, stream);
+};
 
 BTCStateProvider.prototype.getBalanceForAddress = async(network, address) => {
   let query = {chain: this.chain, network, address};
@@ -96,7 +112,7 @@ BTCStateProvider.prototype.updateWallet = (chain, walletId, addresses) => {
 };
 
 BTCStateProvider.prototype.getWalletTransactions = (walletId, stream, args) => {
-  var query = {
+  let query = {
     wallets: walletId
   };
   if (args.startBlock) {
@@ -113,8 +129,8 @@ BTCStateProvider.prototype.getWalletTransactions = (walletId, stream, args) => {
     query.blockTimeNormalized = query.blockTimeNormalized || {};
     query.blockTimeNormalized.$lt = new Date(args.endDate);
   }
-  var transactionStream = Transaction.getTransactions({query});
-  var listTransactionsStream = new ListTransactionsStream(walletId);
+  let transactionStream = Transaction.getTransactions({query});
+  let listTransactionsStream = new ListTransactionsStream(walletId);
   transactionStream.pipe(listTransactionsStream).pipe(stream);
 };
 
@@ -128,7 +144,7 @@ BTCStateProvider.prototype.getWalletUtxos = (walletId, stream, args) => {
   if (args.spent){
     query.spentHeight = { $gt: 0 };
   }
-  Storage.apiStreamingFind(Coin, query, query, stream);
+  Storage.apiStreamingFind(Coin, query, stream);
 };
 
 /*
@@ -137,4 +153,4 @@ BTCStateProvider.prototype.getWalletUtxos = (walletId, stream, args) => {
  *};
  */
 
-module.exports = new BTCStateProvider();
+module.exports = BTCStateProvider;

--- a/lib/providers/chain-state/btc/btc.js
+++ b/lib/providers/chain-state/btc/btc.js
@@ -1,0 +1,140 @@
+const JSONStream = require('JSONStream');
+const ListTransactionsStream = require('./transforms');
+const Storage = require('../../services/storage');
+const mongoose = require('mongoose');
+const Wallet = mongoose.model('Wallet');
+const WalletAddress = mongoose.model('WalletAddress');
+const Transaction = mongoose.model('Transaction');
+const Coin = mongoose.model('Coin');
+const Block = mongoose.model('Coin');
+
+function BTCStateProvider(chain) {
+  this.chain = chain.toUpperCase() || 'BTC';
+}
+
+BTCStateProvider.prototype.getBalanceForAddress = async(network, address) => {
+  let query = {chain: this.chain, network, address};
+  return Coin.getBalance({ query }).exec();
+};
+
+BTCStateProvider.prototype.getBalanceForWallet = async(walletId) => {
+  let query = { wallets: walletId};
+  return Coin.getBalance({query}).exec();
+};
+
+BTCStateProvider.prototype.getBlock = async(network, blockId) => {
+  if (typeof blockId !== 'string' || !this.chain || !network){
+    throw 'Missing required param';
+  }
+  network = network.toLowerCase();
+  let query = {chain: this.chain, network};
+  if (blockId.length === 64){
+    query.hash = blockId;
+  } else {
+    let height = parseInt(blockId, 10);
+    if (Number.isNaN(height) || height.toString(10) !== blockId) {
+      throw 'invalid block id provided';
+    }
+    query.height = height;
+  }
+  let block = await Block.findOne(query);
+  if(!block) {
+    throw 'block not found';
+  }
+  return Block._apiTransform(block,{object:true});
+};
+
+BTCStateProvider.prototype.getTransactions = async(network, stream, args) => {
+  if (!this.chain || !network) {
+    throw 'Missing chain or network';
+  }
+  network = network.toLowerCase();
+  let query = {chain: this.chain, network};
+  if(args.blockHeight) {
+    query.blockHeight = parseInt(args.blockHeight);
+  }
+  if(args.blockHash) {
+    query.blockHash = args.blockHash;
+  }
+  Transaction.getTransactions({ query }).pipe(JSONStream.stringify()).pipe(stream);
+};
+
+BTCStateProvider.prototype.getTransaction = (network, txId, stream) => {
+  if (typeof txid !== 'string' || !this.chain || !network || !stream) {
+    throw 'Missing required param';
+  }
+  network = network.toLowerCase();
+  let query = {chain: this.chain, network, txid: txId};
+  Transaction.getTransactions({ query }).pipe(JSONStream.stringify()).pipe(stream);
+};
+
+BTCStateProvider.prototype.createWallet = async (network, name, pubKey, args) => {
+  if (typeof name !== 'string' || !network) {
+    throw 'Missing required param';
+  }
+  return Wallet.create({
+    chain: this.chain,
+    network,
+    name,
+    pubKey,
+    path: args.path
+  });
+};
+
+BTCStateProvider.prototype.getWallet = async (chain, walletId) => {
+  let wallet = await Wallet.findOne({ _id: walletId }).exec();
+  return Wallet._apiTransform(wallet);
+};
+
+BTCStateProvider.prototype.getWalletAddresses = async(walletId, stream) => {
+  let query = { wallet: walletId };
+  Storage.apiStreamingFind(WalletAddress, query, stream);
+};
+
+BTCStateProvider.prototype.updateWallet = (chain, walletId, addresses) => {
+  return WalletAddress.updateCoins(walletId, addresses);
+};
+
+BTCStateProvider.prototype.getWalletTransactions = (walletId, stream, args) => {
+  var query = {
+    wallets: walletId
+  };
+  if (args.startBlock) {
+    query.blockHeight = { $gte: parseInt(args.startBlock) };
+  }
+  if (args.endBlock) {
+    query.blockHeight = query.blockHeight || {};
+    query.blockHeight.$lte = parseInt(args.endBlock);
+  }
+  if (args.startDate) {
+    query.blockTimeNormalized = { $gte: new Date(args.startDate) };
+  }
+  if (args.endDate) {
+    query.blockTimeNormalized = query.blockTimeNormalized || {};
+    query.blockTimeNormalized.$lt = new Date(args.endDate);
+  }
+  var transactionStream = Transaction.getTransactions({query});
+  var listTransactionsStream = new ListTransactionsStream(walletId);
+  transactionStream.pipe(listTransactionsStream).pipe(stream);
+};
+
+BTCStateProvider.prototype.getWalletBalance = async (walletId) => {
+  let query = { wallets: walletId };
+  return Coin.getBalance({query}).exec();
+};
+
+BTCStateProvider.prototype.getWalletUtxos = (walletId, stream, args) => {
+  let query = { wallets: walletId, spentHeight: {$lt: 0} };
+  if (args.spent){
+    query.spentHeight = { $gt: 0 };
+  }
+  Storage.apiStreamingFind(Coin, query, query, stream);
+};
+
+/*
+ *BTCStateProvider.prototype.broadcastTransaction = (chain, tx) => {
+ *  return this.get(chain).broadcastTransaction(tx);
+ *};
+ */
+
+module.exports = new BTCStateProvider();

--- a/lib/providers/chain-state/btc/btc.js
+++ b/lib/providers/chain-state/btc/btc.js
@@ -13,7 +13,7 @@ function BTCStateProvider(chain){
   this.chain = this.chain.toUpperCase();
 }
 
-BTCStateProvider.prototype.streamAddressUtxos = async function(network, address, stream, args) {
+BTCStateProvider.prototype.streamAddressUtxos = function(network, address, stream, args) {
   if (typeof address !== 'string' || !this.chain || !network) {
     throw 'Missing required param';
   }
@@ -100,7 +100,7 @@ BTCStateProvider.prototype.getWallet = async function(network, walletId){
   return Wallet._apiTransform(wallet);
 };
 
-BTCStateProvider.prototype.streamWalletAddresses = async function(network, walletId, stream){
+BTCStateProvider.prototype.streamWalletAddresses = function(network, walletId, stream){
   let query = { wallet: walletId };
   Storage.apiStreamingFind(WalletAddress, query, stream);
 };
@@ -142,7 +142,7 @@ BTCStateProvider.prototype.getWalletBalance = async function(network, walletId) 
   return Coin.getBalance({query}).exec();
 };
 
-BTCStateProvider.prototype.streamWalletUtxos = async function(network, walletId, stream, args) {
+BTCStateProvider.prototype.streamWalletUtxos = function(network, walletId, stream, args) {
   let query = { wallets: walletId, spentHeight: {$lt: 0} };
   args = args || {};
   if (args.spent){

--- a/lib/providers/chain-state/btc/btc.js
+++ b/lib/providers/chain-state/btc/btc.js
@@ -105,27 +105,29 @@ BTCStateProvider.prototype.getWalletAddresses = async function(network, walletId
   Storage.apiStreamingFind(WalletAddress, query, stream);
 };
 
-BTCStateProvider.prototype.updateWallet = async function(chain, walletId, addresses) {
+BTCStateProvider.prototype.updateWallet = async function(network, walletId, addresses) {
   return WalletAddress.updateCoins(walletId, addresses);
 };
 
-BTCStateProvider.prototype.getWalletTransactions = async function(walletId, stream, args) {
+BTCStateProvider.prototype.getWalletTransactions = async function(network, walletId, stream, args) {
   let query = {
     wallets: walletId
   };
-  if (args.startBlock) {
-    query.blockHeight = { $gte: parseInt(args.startBlock) };
-  }
-  if (args.endBlock) {
-    query.blockHeight = query.blockHeight || {};
-    query.blockHeight.$lte = parseInt(args.endBlock);
-  }
-  if (args.startDate) {
-    query.blockTimeNormalized = { $gte: new Date(args.startDate) };
-  }
-  if (args.endDate) {
-    query.blockTimeNormalized = query.blockTimeNormalized || {};
-    query.blockTimeNormalized.$lt = new Date(args.endDate);
+  if(args) {
+    if (args.startBlock) {
+      query.blockHeight = { $gte: parseInt(args.startBlock) };
+    }
+    if (args.endBlock) {
+      query.blockHeight = query.blockHeight || {};
+      query.blockHeight.$lte = parseInt(args.endBlock);
+    }
+    if (args.startDate) {
+      query.blockTimeNormalized = { $gte: new Date(args.startDate) };
+    }
+    if (args.endDate) {
+      query.blockTimeNormalized = query.blockTimeNormalized || {};
+      query.blockTimeNormalized.$lt = new Date(args.endDate);
+    }
   }
   let transactionStream = Transaction.getTransactions({query});
   let listTransactionsStream = new ListTransactionsStream(walletId);
@@ -146,7 +148,7 @@ BTCStateProvider.prototype.getWalletUtxos = async function(walletId, stream, arg
 };
 
 /*
- *BTCStateProvider.prototype.broadcastTransaction = async function(chain, tx) {
+ *BTCStateProvider.prototype.broadcastTransaction = async function(network, tx) {
  *  return this.get(chain).broadcastTransaction(tx);
  *};
  */

--- a/lib/providers/chain-state/btc/btc.js
+++ b/lib/providers/chain-state/btc/btc.js
@@ -95,7 +95,7 @@ BTCStateProvider.prototype.createWallet = async function(network, name, pubKey, 
   });
 };
 
-BTCStateProvider.prototype.getWallet = async function(chain, walletId){
+BTCStateProvider.prototype.getWallet = async function(network, walletId){
   let wallet = await Wallet.findOne({ _id: walletId }).exec();
   return Wallet._apiTransform(wallet);
 };

--- a/lib/providers/chain-state/btc/btc.js
+++ b/lib/providers/chain-state/btc/btc.js
@@ -8,14 +8,12 @@ const Transaction = mongoose.model('Transaction');
 const Coin = mongoose.model('Coin');
 const Block = mongoose.model('Coin');
 
-function BTCStateProvider(){}
-
-BTCStateProvider.prototype = (chain)=> {
+function BTCStateProvider(chain){
   this.chain = chain || 'BTC';
   this.chain = this.chain.toUpperCase();
-};
+}
 
-BTCStateProvider.prototype.getAddressUtxos = async(network, address, stream, args) => {
+BTCStateProvider.prototype.getAddressUtxos = async function(network, address, stream, args) {
   if (typeof address !== 'string' || !this.chain || !network) {
     throw 'Missing required param';
   }
@@ -28,17 +26,17 @@ BTCStateProvider.prototype.getAddressUtxos = async(network, address, stream, arg
   Storage.apiStreamingFind(Coin, query, stream);
 };
 
-BTCStateProvider.prototype.getBalanceForAddress = async(network, address) => {
+BTCStateProvider.prototype.getBalanceForAddress = async function(network, address){
   let query = {chain: this.chain, network, address};
   return Coin.getBalance({ query }).exec();
 };
 
-BTCStateProvider.prototype.getBalanceForWallet = async(walletId) => {
+BTCStateProvider.prototype.getBalanceForWallet = async function(walletId){
   let query = { wallets: walletId};
   return Coin.getBalance({query}).exec();
 };
 
-BTCStateProvider.prototype.getBlock = async(network, blockId) => {
+BTCStateProvider.prototype.getBlock = async function(network, blockId){
   if (typeof blockId !== 'string' || !this.chain || !network){
     throw 'Missing required param';
   }
@@ -60,7 +58,7 @@ BTCStateProvider.prototype.getBlock = async(network, blockId) => {
   return Block._apiTransform(block,{object:true});
 };
 
-BTCStateProvider.prototype.getTransactions = async(network, stream, args) => {
+BTCStateProvider.prototype.getTransactions = async function(network, stream, args){
   if (!this.chain || !network) {
     throw 'Missing chain or network';
   }
@@ -102,7 +100,7 @@ BTCStateProvider.prototype.getWallet = async (chain, walletId) => {
   return Wallet._apiTransform(wallet);
 };
 
-BTCStateProvider.prototype.getWalletAddresses = async(walletId, stream) => {
+BTCStateProvider.prototype.getWalletAddresses = async function(walletId, stream){
   let query = { wallet: walletId };
   Storage.apiStreamingFind(WalletAddress, query, stream);
 };

--- a/lib/providers/chain-state/btc/btc.js
+++ b/lib/providers/chain-state/btc/btc.js
@@ -134,8 +134,8 @@ BTCStateProvider.prototype.getWalletTransactions = async function(network, walle
   transactionStream.pipe(listTransactionsStream).pipe(stream);
 };
 
-BTCStateProvider.prototype.getWalletBalance = async function(walletId) {
-  let query = { wallets: walletId };
+BTCStateProvider.prototype.getWalletBalance = async function(network, walletId) {
+  let query = { wallets: mongoose.Types.ObjectId(walletId)};
   return Coin.getBalance({query}).exec();
 };
 

--- a/lib/providers/chain-state/btc/btc.js
+++ b/lib/providers/chain-state/btc/btc.js
@@ -58,7 +58,7 @@ BTCStateProvider.prototype.getBlock = async function(network, blockId){
   return Block._apiTransform(block,{object:true});
 };
 
-BTCStateProvider.prototype.getTransactions = async function(network, stream, args){
+BTCStateProvider.prototype.streamTransactions = function(network, stream, args){
   if (!this.chain || !network) {
     throw 'Missing chain or network';
   }
@@ -73,7 +73,7 @@ BTCStateProvider.prototype.getTransactions = async function(network, stream, arg
   Transaction.getTransactions({ query }).pipe(JSONStream.stringify()).pipe(stream);
 };
 
-BTCStateProvider.prototype.getTransaction = async function (network, txId, stream){
+BTCStateProvider.prototype.streamTransaction = function (network, txId, stream){
   if (typeof txid !== 'string' || !this.chain || !network || !stream) {
     throw 'Missing required param';
   }

--- a/lib/providers/chain-state/btc/btc.js
+++ b/lib/providers/chain-state/btc/btc.js
@@ -139,8 +139,9 @@ BTCStateProvider.prototype.getWalletBalance = async function(network, walletId) 
   return Coin.getBalance({query}).exec();
 };
 
-BTCStateProvider.prototype.getWalletUtxos = async function(walletId, stream, args) {
+BTCStateProvider.prototype.getWalletUtxos = async function(network, walletId, stream, args) {
   let query = { wallets: walletId, spentHeight: {$lt: 0} };
+  args = args || {};
   if (args.spent){
     query.spentHeight = { $gt: 0 };
   }

--- a/lib/providers/chain-state/btc/btc.js
+++ b/lib/providers/chain-state/btc/btc.js
@@ -13,7 +13,7 @@ function BTCStateProvider(chain){
   this.chain = this.chain.toUpperCase();
 }
 
-BTCStateProvider.prototype.getAddressUtxos = async function(network, address, stream, args) {
+BTCStateProvider.prototype.streamAddressUtxos = async function(network, address, stream, args) {
   if (typeof address !== 'string' || !this.chain || !network) {
     throw 'Missing required param';
   }
@@ -74,7 +74,7 @@ BTCStateProvider.prototype.streamTransactions = function(network, stream, args){
 };
 
 BTCStateProvider.prototype.streamTransaction = function (network, txId, stream){
-  if (typeof txid !== 'string' || !this.chain || !network || !stream) {
+  if (typeof txId !== 'string' || !this.chain || !network || !stream) {
     throw 'Missing required param';
   }
   network = network.toLowerCase();
@@ -100,7 +100,7 @@ BTCStateProvider.prototype.getWallet = async function(network, walletId){
   return Wallet._apiTransform(wallet);
 };
 
-BTCStateProvider.prototype.getWalletAddresses = async function(network, walletId, stream){
+BTCStateProvider.prototype.streamWalletAddresses = async function(network, walletId, stream){
   let query = { wallet: walletId };
   Storage.apiStreamingFind(WalletAddress, query, stream);
 };
@@ -109,7 +109,7 @@ BTCStateProvider.prototype.updateWallet = async function(network, walletId, addr
   return WalletAddress.updateCoins({chain: this.chain, _id: walletId, network},  addresses);
 };
 
-BTCStateProvider.prototype.getWalletTransactions = async function(network, walletId, stream, args) {
+BTCStateProvider.prototype.streamWalletTransactions = async function(network, walletId, stream, args) {
   let wallet = await Wallet.findOne({ _id: walletId }).exec();
   let query = {
     chain: this.chain,
@@ -142,7 +142,7 @@ BTCStateProvider.prototype.getWalletBalance = async function(network, walletId) 
   return Coin.getBalance({query}).exec();
 };
 
-BTCStateProvider.prototype.getWalletUtxos = async function(network, walletId, stream, args) {
+BTCStateProvider.prototype.streamWalletUtxos = async function(network, walletId, stream, args) {
   let query = { wallets: walletId, spentHeight: {$lt: 0} };
   args = args || {};
   if (args.spent){

--- a/lib/providers/chain-state/btc/btc.js
+++ b/lib/providers/chain-state/btc/btc.js
@@ -106,7 +106,7 @@ BTCStateProvider.prototype.getWalletAddresses = async function(network, walletId
 };
 
 BTCStateProvider.prototype.updateWallet = async function(network, walletId, addresses) {
-  return WalletAddress.updateCoins(walletId, addresses);
+  return WalletAddress.updateCoins({chain: this.chain, _id: walletId, network},  addresses);
 };
 
 BTCStateProvider.prototype.getWalletTransactions = async function(network, walletId, stream, args) {

--- a/lib/providers/chain-state/btc/btc.js
+++ b/lib/providers/chain-state/btc/btc.js
@@ -26,7 +26,7 @@ BTCStateProvider.prototype.getAddressUtxos = async function(network, address, st
   Storage.apiStreamingFind(Coin, query, stream);
 };
 
-BTCStateProvider.prototype.getBalanceForAddress = async function(network, address){
+BTCStateProvider.prototype.getBalanceForAddress = function(network, address){
   let query = {chain: this.chain, network, address};
   return Coin.getBalance({ query }).exec();
 };
@@ -73,7 +73,7 @@ BTCStateProvider.prototype.getTransactions = async function(network, stream, arg
   Transaction.getTransactions({ query }).pipe(JSONStream.stringify()).pipe(stream);
 };
 
-BTCStateProvider.prototype.getTransaction = (network, txId, stream) => {
+BTCStateProvider.prototype.getTransaction = async function (network, txId, stream){
   if (typeof txid !== 'string' || !this.chain || !network || !stream) {
     throw 'Missing required param';
   }
@@ -82,7 +82,7 @@ BTCStateProvider.prototype.getTransaction = (network, txId, stream) => {
   Transaction.getTransactions({ query }).pipe(JSONStream.stringify()).pipe(stream);
 };
 
-BTCStateProvider.prototype.createWallet = async (network, name, pubKey, args) => {
+BTCStateProvider.prototype.createWallet = async function(network, name, pubKey, args){
   if (typeof name !== 'string' || !network) {
     throw 'Missing required param';
   }
@@ -95,7 +95,7 @@ BTCStateProvider.prototype.createWallet = async (network, name, pubKey, args) =>
   });
 };
 
-BTCStateProvider.prototype.getWallet = async (chain, walletId) => {
+BTCStateProvider.prototype.getWallet = async function(chain, walletId){
   let wallet = await Wallet.findOne({ _id: walletId }).exec();
   return Wallet._apiTransform(wallet);
 };
@@ -105,11 +105,11 @@ BTCStateProvider.prototype.getWalletAddresses = async function(walletId, stream)
   Storage.apiStreamingFind(WalletAddress, query, stream);
 };
 
-BTCStateProvider.prototype.updateWallet = (chain, walletId, addresses) => {
+BTCStateProvider.prototype.updateWallet = async function(chain, walletId, addresses) {
   return WalletAddress.updateCoins(walletId, addresses);
 };
 
-BTCStateProvider.prototype.getWalletTransactions = (walletId, stream, args) => {
+BTCStateProvider.prototype.getWalletTransactions = async function(walletId, stream, args) {
   let query = {
     wallets: walletId
   };
@@ -132,12 +132,12 @@ BTCStateProvider.prototype.getWalletTransactions = (walletId, stream, args) => {
   transactionStream.pipe(listTransactionsStream).pipe(stream);
 };
 
-BTCStateProvider.prototype.getWalletBalance = async (walletId) => {
+BTCStateProvider.prototype.getWalletBalance = async function(walletId) {
   let query = { wallets: walletId };
   return Coin.getBalance({query}).exec();
 };
 
-BTCStateProvider.prototype.getWalletUtxos = (walletId, stream, args) => {
+BTCStateProvider.prototype.getWalletUtxos = async function(walletId, stream, args) {
   let query = { wallets: walletId, spentHeight: {$lt: 0} };
   if (args.spent){
     query.spentHeight = { $gt: 0 };
@@ -146,7 +146,7 @@ BTCStateProvider.prototype.getWalletUtxos = (walletId, stream, args) => {
 };
 
 /*
- *BTCStateProvider.prototype.broadcastTransaction = (chain, tx) => {
+ *BTCStateProvider.prototype.broadcastTransaction = async function(chain, tx) {
  *  return this.get(chain).broadcastTransaction(tx);
  *};
  */

--- a/lib/providers/chain-state/btc/btc.js
+++ b/lib/providers/chain-state/btc/btc.js
@@ -6,7 +6,7 @@ const Wallet = mongoose.model('Wallet');
 const WalletAddress = mongoose.model('WalletAddress');
 const Transaction = mongoose.model('Transaction');
 const Coin = mongoose.model('Coin');
-const Block = mongoose.model('Coin');
+const Block = mongoose.model('Block');
 
 function BTCStateProvider(chain){
   this.chain = chain || 'BTC';
@@ -41,7 +41,7 @@ BTCStateProvider.prototype.getBlock = async function(network, blockId){
     throw 'Missing required param';
   }
   network = network.toLowerCase();
-  let query = {chain: this.chain, network};
+  let query = {chain: this.chain, network, processed: true};
   if (blockId.length === 64){
     query.hash = blockId;
   } else {
@@ -51,7 +51,7 @@ BTCStateProvider.prototype.getBlock = async function(network, blockId){
     }
     query.height = height;
   }
-  let block = await Block.findOne(query);
+  let block = await Block.find(query).exec();
   if(!block) {
     throw 'block not found';
   }

--- a/lib/providers/chain-state/btc/btc.js
+++ b/lib/providers/chain-state/btc/btc.js
@@ -100,7 +100,7 @@ BTCStateProvider.prototype.getWallet = async function(network, walletId){
   return Wallet._apiTransform(wallet);
 };
 
-BTCStateProvider.prototype.getWalletAddresses = async function(walletId, stream){
+BTCStateProvider.prototype.getWalletAddresses = async function(network, walletId, stream){
   let query = { wallet: walletId };
   Storage.apiStreamingFind(WalletAddress, query, stream);
 };

--- a/lib/providers/chain-state/btc/transforms.js
+++ b/lib/providers/chain-state/btc/transforms.js
@@ -1,0 +1,88 @@
+const {Transform} = require('stream');
+const util = require('util');
+const _ = require('underscore');
+const logger = require('../../logger.js');
+
+function ListTransactionsStream(walletId) {
+  this.walletId = walletId;
+  Transform.call(this, {objectMode: true});
+}
+
+util.inherits(ListTransactionsStream, Transform);
+
+ListTransactionsStream.prototype._transform = function(transaction, enc, done) {
+  var self = this;
+  var wallet = this.walletId.toString();
+  var totalInputs = transaction.inputs.reduce((total, input) => { return total + input.value; }, 0);
+  var totalOutputs = transaction.outputs.reduce((total, output) => { return total + output.value; }, 0);
+  var fee = totalInputs - totalOutputs;
+  var sending = _.some(transaction.inputs, function(input) {
+    var contains = false;
+    _.each(input.wallets, function(inputWallet) {
+      if(inputWallet.equals(wallet)) {
+        contains = true;
+      }
+    });
+    return contains;
+  });
+
+  if(sending) {
+    var recipients = 0;
+    _.each(transaction.outputs, function(output) {
+      var contains = false;
+      _.each(output.wallets, function(outputWallet) {
+        if(outputWallet.equals(wallet)) {
+          contains = true;
+        }
+      });
+      if(!contains) {
+        recipients++;
+        self.push(JSON.stringify({
+          txid: transaction.txid,
+          category: 'send',
+          satoshis: -output.value,
+          height: transaction.blockHeight,
+          address: output.address,
+          outputIndex: output.vout,
+          blockTime: transaction.blockTimeNormalized
+        }) + '\n');
+      }
+    });
+    if (recipients > 1){
+      logger.warn('probably missing a change address', {txid: transaction.txid});
+    }
+    if(fee > 0) {
+      self.push(JSON.stringify({
+        txid: transaction.txid,
+        category: 'fee',
+        satoshis: -fee,
+        height: transaction.blockHeight,
+        blockTime: transaction.blockTimeNormalized
+      }) + '\n');
+    }
+    return done();
+  }
+
+  _.each(transaction.outputs, function(output) {
+    var contains = false;
+    _.each(output.wallets, function(outputWallet) {
+      if(outputWallet.equals(wallet)) {
+        contains = true;
+      }
+    });
+    if(contains) {
+      self.push(JSON.stringify({
+        txid: transaction.txid,
+        category: 'receive',
+        satoshis: output.value,
+        height: transaction.blockHeight,
+        address: output.address,
+        outputIndex: output.vout,
+        blockTime: transaction.blockTimeNormalized
+      }) + '\n');
+    }
+  });
+  done();
+};
+
+

--- a/lib/providers/chain-state/btc/transforms.js
+++ b/lib/providers/chain-state/btc/transforms.js
@@ -1,7 +1,7 @@
 const {Transform} = require('stream');
 const util = require('util');
 const _ = require('underscore');
-const logger = require('../../logger.js');
+const logger = require('../../../logger');
 
 function ListTransactionsStream(walletId) {
   this.walletId = walletId;

--- a/lib/providers/chain-state/btc/transforms.js
+++ b/lib/providers/chain-state/btc/transforms.js
@@ -85,4 +85,4 @@ ListTransactionsStream.prototype._transform = function(transaction, enc, done) {
   done();
 };
 
-
+module.exports = ListTransactionsStream;

--- a/lib/providers/chain-state/index.js
+++ b/lib/providers/chain-state/index.js
@@ -48,8 +48,8 @@ ChainStateProvider.prototype.getWallet = async function (chain, network, walletI
   return this.get(chain).getWallet(network, walletId);
 };
 
-ChainStateProvider.prototype.getWalletAddresses = async function (chain, network, walletId) {
-  return this.get(chain).getWalletAddresses(walletId);
+ChainStateProvider.prototype.getWalletAddresses = async function (chain, network, walletId, stream) {
+  return this.get(chain).getWalletAddresses(network, walletId, stream);
 };
 
 ChainStateProvider.prototype.updateWallet = async function (chain, network,  walletId) {

--- a/lib/providers/chain-state/index.js
+++ b/lib/providers/chain-state/index.js
@@ -3,14 +3,11 @@ const BCHStateProvider = require('./bch/bch');
 
 const providers = {
   BTC: new BTCStateProvider(),
-  BCH: new BCHStateProvider(),
-  ETH: require('./eth/eth')
+  BCH: new BCHStateProvider()
 };
 
 
-function ChainStateProvider() {
-
-}
+function ChainStateProvider() { }
 
 ChainStateProvider.prototype.get = function (chain) {
   return providers[chain];
@@ -32,12 +29,12 @@ ChainStateProvider.prototype.getBlock = async function (chain, network, blockId)
   return this.get(chain).getBlock(network, blockId);
 };
 
-ChainStateProvider.prototype.getTransactions = async function (chain,network,params) {
-  return this.get(chain).getTransactions(params);
+ChainStateProvider.prototype.streamTransactions = async function (chain, network, stream, params) {
+  return this.get(chain).streamTransactions(network, stream, params);
 };
 
-ChainStateProvider.prototype.getTransaction = async function (chain, network, txId) {
-  return this.get(chain).getTransaction(txId);
+ChainStateProvider.prototype.streamTransaction = async function (chain, network, txId, stream) {
+  return this.get(chain).streamTransaction(network, txId, stream);
 };
 
 ChainStateProvider.prototype.createWallet = async function (chain, network, name, pubkey, params) {

--- a/lib/providers/chain-state/index.js
+++ b/lib/providers/chain-state/index.js
@@ -56,8 +56,8 @@ ChainStateProvider.prototype.updateWallet = async function (chain, network,  wal
   return this.get(chain).updateWallet(walletId);
 };
 
-ChainStateProvider.prototype.getWalletTransactions = async function (chain, network, walletId) {
-  return this.get(chain).getWalletTransactions(walletId);
+ChainStateProvider.prototype.getWalletTransactions = async function (chain, network, walletId, stream, args) {
+  return this.get(chain).getWalletTransactions(network, walletId, stream, args);
 };
 
 ChainStateProvider.prototype.getWalletBalance = async function (chain, network, walletId) {

--- a/lib/providers/chain-state/index.js
+++ b/lib/providers/chain-state/index.js
@@ -40,8 +40,8 @@ ChainStateProvider.prototype.getTransaction = async function (chain, network, tx
   return this.get(chain).getTransaction(txId);
 };
 
-ChainStateProvider.prototype.createWallet = async function (chain, network, params) {
-  return this.get(chain).createWallet(params);
+ChainStateProvider.prototype.createWallet = async function (chain, network, name, pubkey, params) {
+  return this.get(chain).createWallet(network, name, pubkey, params);
 };
 
 ChainStateProvider.prototype.getWallet = async function (chain, network, walletId) {

--- a/lib/providers/chain-state/index.js
+++ b/lib/providers/chain-state/index.js
@@ -1,5 +1,6 @@
 const BTCStateProvider = require('./btc/btc');
 const BCHStateProvider = require('./bch/bch');
+
 const providers = {
   BTC: new BTCStateProvider(),
   BCH: new BCHStateProvider(),
@@ -11,7 +12,7 @@ function ChainStateProvider() {
 
 }
 
-ChainStateProvider.prototype.get = (chain) => {
+ChainStateProvider.prototype.get = function (chain) {
   return providers[chain];
 };
 
@@ -20,55 +21,55 @@ ChainStateProvider.prototype.getAddressUtxos = async function (chain, network, a
 };
 
 ChainStateProvider.prototype.getBalanceForAddress = async function (chain, network, address){
-  return this.get(chain).getBalanceForAddress(address);
+  return this.get(chain).getBalanceForAddress(network, address);
 };
 
-ChainStateProvider.prototype.getBalanceForWallet = (chain,network,wallet) => {
+ChainStateProvider.prototype.getBalanceForWallet = async function (chain,network,wallet) {
   return this.get(chain).getBalanceForWallet(wallet);
 };
 
-ChainStateProvider.prototype.getBlock = (chain,  network,blockId) => {
+ChainStateProvider.prototype.getBlock = async function (chain,  network,blockId) {
   return this.get(chain).getBlock(blockId);
 };
 
-ChainStateProvider.prototype.getTransactions = (chain,network,params) => {
+ChainStateProvider.prototype.getTransactions = async function (chain,network,params) {
   return this.get(chain).getTransactions(params);
 };
 
-ChainStateProvider.prototype.getTransaction = (chain, network, txId) => {
+ChainStateProvider.prototype.getTransaction = async function (chain, network, txId) {
   return this.get(chain).getTransaction(txId);
 };
 
-ChainStateProvider.prototype.createWallet = (chain,network,  params) => {
+ChainStateProvider.prototype.createWallet = async function (chain,network,  params) {
   return this.get(chain).createWallet(params);
 };
 
-ChainStateProvider.prototype.getWallet = (chain, network, walletId) => {
+ChainStateProvider.prototype.getWallet = async function (chain, network, walletId) {
   return this.get(chain).getWallet(walletId);
 };
 
-ChainStateProvider.prototype.getWalletAddresses = (chain, network, walletId) => {
+ChainStateProvider.prototype.getWalletAddresses = async function (chain, network, walletId) {
   return this.get(chain).getWalletAddresses(walletId);
 };
 
-ChainStateProvider.prototype.updateWallet = (chain, network,  walletId) => {
+ChainStateProvider.prototype.updateWallet = async function (chain, network,  walletId) {
   return this.get(chain).updateWallet(walletId);
 };
 
-ChainStateProvider.prototype.getWalletTransactions = (chain, network, walletId) => {
+ChainStateProvider.prototype.getWalletTransactions = async function (chain, network, walletId) {
   return this.get(chain).getWalletTransactions(walletId);
 };
 
-ChainStateProvider.prototype.getWalletBalance = (chain, network, walletId) => {
+ChainStateProvider.prototype.getWalletBalance = async function (chain, network, walletId) {
   return this.get(chain).getWalletBalance(walletId);
 };
 
-ChainStateProvider.prototype.getWalletUtxos = (chain, network, walletId) => {
+ChainStateProvider.prototype.getWalletUtxos = async function (chain, network, walletId) {
   return this.get(chain).getWalletUtxos(walletId);
 };
 
 /*
- *ChainStateProvider.prototype.broadcastTransaction = (chain, network , tx) => {
+ *ChainStateProvider.prototype.broadcastTransaction = async function (chain, network , tx) {
  *  return this.get(chain).broadcastTransaction(tx);
  *};
  */

--- a/lib/providers/chain-state/index.js
+++ b/lib/providers/chain-state/index.js
@@ -1,0 +1,68 @@
+const providers = {
+  BTC: require('./btc'),
+  BCH: require('./bch'),
+  ETH: require('./eth')
+};
+
+
+function ChainStateProvider() {
+  
+}
+
+ChainStateProvider.prototype.get = (chain) => {
+  return providers[chain];
+};
+
+ChainStateProvider.prototype.getBalanceForAddress = (chain, address) => {
+  return this.get(chain).getBalanceForAddress(address);
+};
+
+ChainStateProvider.prototype.getBalanceForWallet = (chain, wallet) => {
+  return this.get(chain).getBalanceForWallet(wallet);
+};
+
+ChainStateProvider.prototype.getBlock = (chain, blockId) => {
+  return this.get(chain).getBlock(blockId);
+};
+
+ChainStateProvider.prototype.getTransactions = (chain, params) => {
+  return this.get(chain).getTransactions(params);
+};
+
+ChainStateProvider.prototype.getTransaction = (chain, txId) => {
+  return this.get(chain).getTransaction(txId);
+};
+
+ChainStateProvider.prototype.createWallet = (chain, params) => {
+  return this.get(chain).createWallet(params);
+};
+
+ChainStateProvider.prototype.getWallet = (chain, walletId) => {
+  return this.get(chain).getWallet(walletId);
+};
+
+ChainStateProvider.prototype.getWalletAddresses = (chain, walletId) => {
+  return this.get(chain).getWalletAddresses(walletId);
+};
+
+ChainStateProvider.prototype.updateWallet = (chain, walletId) => {
+  return this.get(chain).updateWallet(walletId);
+};
+
+ChainStateProvider.prototype.getWalletTransactions = (chain, walletId) => {
+  return this.get(chain).getWalletTransactions(walletId);
+};
+
+ChainStateProvider.prototype.getWalletBalance = (chain, walletId) => {
+  return this.get(chain).getWalletBalance(walletId);
+};
+
+ChainStateProvider.prototype.getWalletUtxos = (chain, walletId) => {
+  return this.get(chain).getWalletUtxos(walletId);
+};
+
+ChainStateProvider.prototype.broadcastTransaction = (chain, tx) => {
+  return this.get(chain).broadcastTransaction(tx);
+};
+
+module.exports = new ChainStateProvider();

--- a/lib/providers/chain-state/index.js
+++ b/lib/providers/chain-state/index.js
@@ -13,7 +13,7 @@ ChainStateProvider.prototype.get = function (chain) {
   return providers[chain];
 };
 
-ChainStateProvider.prototype.streamAddressUtxos = async function (chain, network, address, stream, args){
+ChainStateProvider.prototype.streamAddressUtxos = function (chain, network, address, stream, args){
   return this.get(chain).streamAddressUtxos(network, address, stream, args);
 };
 
@@ -45,7 +45,7 @@ ChainStateProvider.prototype.getWallet = async function (chain, network, walletI
   return this.get(chain).getWallet(network, walletId);
 };
 
-ChainStateProvider.prototype.streamWalletAddresses = async function (chain, network, walletId, stream) {
+ChainStateProvider.prototype.streamWalletAddresses = function (chain, network, walletId, stream) {
   return this.get(chain).streamWalletAddresses(network, walletId, stream);
 };
 
@@ -53,7 +53,7 @@ ChainStateProvider.prototype.updateWallet = async function (chain, network,  wal
   return this.get(chain).updateWallet(network, walletId, addresses);
 };
 
-ChainStateProvider.prototype.streamWalletTransactions = async function (chain, network, walletId, stream, args) {
+ChainStateProvider.prototype.streamWalletTransactions = function (chain, network, walletId, stream, args) {
   return this.get(chain).streamWalletTransactions(network, walletId, stream, args);
 };
 
@@ -61,7 +61,7 @@ ChainStateProvider.prototype.getWalletBalance = async function (chain, network, 
   return this.get(chain).getWalletBalance(network, walletId);
 };
 
-ChainStateProvider.prototype.streamWalletUtxos = async function (chain, network, walletId, stream) {
+ChainStateProvider.prototype.streamWalletUtxos = function (chain, network, walletId, stream) {
   return this.get(chain).streamWalletUtxos(network, walletId, stream);
 };
 

--- a/lib/providers/chain-state/index.js
+++ b/lib/providers/chain-state/index.js
@@ -24,11 +24,11 @@ ChainStateProvider.prototype.getBalanceForAddress = async function (chain, netwo
   return this.get(chain).getBalanceForAddress(network, address);
 };
 
-ChainStateProvider.prototype.getBalanceForWallet = async function (chain,network,wallet) {
+ChainStateProvider.prototype.getBalanceForWallet = async function (chain, network, wallet) {
   return this.get(chain).getBalanceForWallet(wallet);
 };
 
-ChainStateProvider.prototype.getBlock = async function (chain,  network,blockId) {
+ChainStateProvider.prototype.getBlock = async function (chain, network, blockId) {
   return this.get(chain).getBlock(blockId);
 };
 
@@ -40,7 +40,7 @@ ChainStateProvider.prototype.getTransaction = async function (chain, network, tx
   return this.get(chain).getTransaction(txId);
 };
 
-ChainStateProvider.prototype.createWallet = async function (chain,network,  params) {
+ChainStateProvider.prototype.createWallet = async function (chain, network, params) {
   return this.get(chain).createWallet(params);
 };
 
@@ -52,8 +52,8 @@ ChainStateProvider.prototype.getWalletAddresses = async function (chain, network
   return this.get(chain).getWalletAddresses(network, walletId, stream);
 };
 
-ChainStateProvider.prototype.updateWallet = async function (chain, network,  walletId) {
-  return this.get(chain).updateWallet(walletId);
+ChainStateProvider.prototype.updateWallet = async function (chain, network,  walletId, addresses) {
+  return this.get(chain).updateWallet(network, walletId, addresses);
 };
 
 ChainStateProvider.prototype.getWalletTransactions = async function (chain, network, walletId, stream, args) {

--- a/lib/providers/chain-state/index.js
+++ b/lib/providers/chain-state/index.js
@@ -29,7 +29,7 @@ ChainStateProvider.prototype.getBalanceForWallet = async function (chain, networ
 };
 
 ChainStateProvider.prototype.getBlock = async function (chain, network, blockId) {
-  return this.get(chain).getBlock(blockId);
+  return this.get(chain).getBlock(network, blockId);
 };
 
 ChainStateProvider.prototype.getTransactions = async function (chain,network,params) {

--- a/lib/providers/chain-state/index.js
+++ b/lib/providers/chain-state/index.js
@@ -45,7 +45,7 @@ ChainStateProvider.prototype.createWallet = async function (chain,network,  para
 };
 
 ChainStateProvider.prototype.getWallet = async function (chain, network, walletId) {
-  return this.get(chain).getWallet(walletId);
+  return this.get(chain).getWallet(network, walletId);
 };
 
 ChainStateProvider.prototype.getWalletAddresses = async function (chain, network, walletId) {

--- a/lib/providers/chain-state/index.js
+++ b/lib/providers/chain-state/index.js
@@ -13,8 +13,8 @@ ChainStateProvider.prototype.get = function (chain) {
   return providers[chain];
 };
 
-ChainStateProvider.prototype.getAddressUtxos = async function (chain, network, address, stream, args){
-  return this.get(chain).getAddressUtxos(network, address, stream, args);
+ChainStateProvider.prototype.streamAddressUtxos = async function (chain, network, address, stream, args){
+  return this.get(chain).streamAddressUtxos(network, address, stream, args);
 };
 
 ChainStateProvider.prototype.getBalanceForAddress = async function (chain, network, address){
@@ -29,11 +29,11 @@ ChainStateProvider.prototype.getBlock = async function (chain, network, blockId)
   return this.get(chain).getBlock(network, blockId);
 };
 
-ChainStateProvider.prototype.streamTransactions = async function (chain, network, stream, params) {
+ChainStateProvider.prototype.streamTransactions = function (chain, network, stream, params) {
   return this.get(chain).streamTransactions(network, stream, params);
 };
 
-ChainStateProvider.prototype.streamTransaction = async function (chain, network, txId, stream) {
+ChainStateProvider.prototype.streamTransaction = function (chain, network, txId, stream) {
   return this.get(chain).streamTransaction(network, txId, stream);
 };
 
@@ -45,24 +45,24 @@ ChainStateProvider.prototype.getWallet = async function (chain, network, walletI
   return this.get(chain).getWallet(network, walletId);
 };
 
-ChainStateProvider.prototype.getWalletAddresses = async function (chain, network, walletId, stream) {
-  return this.get(chain).getWalletAddresses(network, walletId, stream);
+ChainStateProvider.prototype.streamWalletAddresses = async function (chain, network, walletId, stream) {
+  return this.get(chain).streamWalletAddresses(network, walletId, stream);
 };
 
 ChainStateProvider.prototype.updateWallet = async function (chain, network,  walletId, addresses) {
   return this.get(chain).updateWallet(network, walletId, addresses);
 };
 
-ChainStateProvider.prototype.getWalletTransactions = async function (chain, network, walletId, stream, args) {
-  return this.get(chain).getWalletTransactions(network, walletId, stream, args);
+ChainStateProvider.prototype.streamWalletTransactions = async function (chain, network, walletId, stream, args) {
+  return this.get(chain).streamWalletTransactions(network, walletId, stream, args);
 };
 
 ChainStateProvider.prototype.getWalletBalance = async function (chain, network, walletId) {
   return this.get(chain).getWalletBalance(network, walletId);
 };
 
-ChainStateProvider.prototype.getWalletUtxos = async function (chain, network, walletId, stream) {
-  return this.get(chain).getWalletUtxos(network, walletId, stream);
+ChainStateProvider.prototype.streamWalletUtxos = async function (chain, network, walletId, stream) {
+  return this.get(chain).streamWalletUtxos(network, walletId, stream);
 };
 
 /*

--- a/lib/providers/chain-state/index.js
+++ b/lib/providers/chain-state/index.js
@@ -64,8 +64,8 @@ ChainStateProvider.prototype.getWalletBalance = async function (chain, network, 
   return this.get(chain).getWalletBalance(network, walletId);
 };
 
-ChainStateProvider.prototype.getWalletUtxos = async function (chain, network, walletId) {
-  return this.get(chain).getWalletUtxos(walletId);
+ChainStateProvider.prototype.getWalletUtxos = async function (chain, network, walletId, stream) {
+  return this.get(chain).getWalletUtxos(network, walletId, stream);
 };
 
 /*

--- a/lib/providers/chain-state/index.js
+++ b/lib/providers/chain-state/index.js
@@ -1,6 +1,8 @@
+const BTCStateProvider = require('./btc/btc');
+const BCHStateProvider = require('./bch/bch');
 const providers = {
-  BTC: require('./btc/btc'),
-  BCH: require('./bch/bch'),
+  BTC: new BTCStateProvider(),
+  BCH: new BCHStateProvider(),
   ETH: require('./eth/eth')
 };
 
@@ -13,7 +15,7 @@ ChainStateProvider.prototype.get = (chain) => {
   return providers[chain];
 };
 
-ChainStateProvider.prototype.getAddressUtxos = async(chain, network, address, stream, args) => {
+ChainStateProvider.prototype.getAddressUtxos = async function (chain, network, address, stream, args){
   return this.get(chain).getAddressUtxos(network, address, stream, args);
 };
 

--- a/lib/providers/chain-state/index.js
+++ b/lib/providers/chain-state/index.js
@@ -19,7 +19,7 @@ ChainStateProvider.prototype.getAddressUtxos = async function (chain, network, a
   return this.get(chain).getAddressUtxos(network, address, stream, args);
 };
 
-ChainStateProvider.prototype.getBalanceForAddress = (chain, network, address) => {
+ChainStateProvider.prototype.getBalanceForAddress = async function (chain, network, address){
   return this.get(chain).getBalanceForAddress(address);
 };
 

--- a/lib/providers/chain-state/index.js
+++ b/lib/providers/chain-state/index.js
@@ -1,68 +1,74 @@
 const providers = {
-  BTC: require('./btc'),
-  BCH: require('./bch'),
-  ETH: require('./eth')
+  BTC: require('./btc/btc'),
+  BCH: require('./bch/bch'),
+  ETH: require('./eth/eth')
 };
 
 
 function ChainStateProvider() {
-  
+
 }
 
 ChainStateProvider.prototype.get = (chain) => {
   return providers[chain];
 };
 
-ChainStateProvider.prototype.getBalanceForAddress = (chain, address) => {
+ChainStateProvider.prototype.getAddressUtxos = async(chain, network, address, stream, args) => {
+  return this.get(chain).getAddressUtxos(network, address, stream, args);
+};
+
+ChainStateProvider.prototype.getBalanceForAddress = (chain, network, address) => {
   return this.get(chain).getBalanceForAddress(address);
 };
 
-ChainStateProvider.prototype.getBalanceForWallet = (chain, wallet) => {
+ChainStateProvider.prototype.getBalanceForWallet = (chain,network,wallet) => {
   return this.get(chain).getBalanceForWallet(wallet);
 };
 
-ChainStateProvider.prototype.getBlock = (chain, blockId) => {
+ChainStateProvider.prototype.getBlock = (chain,  network,blockId) => {
   return this.get(chain).getBlock(blockId);
 };
 
-ChainStateProvider.prototype.getTransactions = (chain, params) => {
+ChainStateProvider.prototype.getTransactions = (chain,network,params) => {
   return this.get(chain).getTransactions(params);
 };
 
-ChainStateProvider.prototype.getTransaction = (chain, txId) => {
+ChainStateProvider.prototype.getTransaction = (chain, network, txId) => {
   return this.get(chain).getTransaction(txId);
 };
 
-ChainStateProvider.prototype.createWallet = (chain, params) => {
+ChainStateProvider.prototype.createWallet = (chain,network,  params) => {
   return this.get(chain).createWallet(params);
 };
 
-ChainStateProvider.prototype.getWallet = (chain, walletId) => {
+ChainStateProvider.prototype.getWallet = (chain, network, walletId) => {
   return this.get(chain).getWallet(walletId);
 };
 
-ChainStateProvider.prototype.getWalletAddresses = (chain, walletId) => {
+ChainStateProvider.prototype.getWalletAddresses = (chain, network, walletId) => {
   return this.get(chain).getWalletAddresses(walletId);
 };
 
-ChainStateProvider.prototype.updateWallet = (chain, walletId) => {
+ChainStateProvider.prototype.updateWallet = (chain, network,  walletId) => {
   return this.get(chain).updateWallet(walletId);
 };
 
-ChainStateProvider.prototype.getWalletTransactions = (chain, walletId) => {
+ChainStateProvider.prototype.getWalletTransactions = (chain, network, walletId) => {
   return this.get(chain).getWalletTransactions(walletId);
 };
 
-ChainStateProvider.prototype.getWalletBalance = (chain, walletId) => {
+ChainStateProvider.prototype.getWalletBalance = (chain, network, walletId) => {
   return this.get(chain).getWalletBalance(walletId);
 };
 
-ChainStateProvider.prototype.getWalletUtxos = (chain, walletId) => {
+ChainStateProvider.prototype.getWalletUtxos = (chain, network, walletId) => {
   return this.get(chain).getWalletUtxos(walletId);
 };
 
-ChainStateProvider.prototype.broadcastTransaction = (chain, tx) => {
-  return this.get(chain).broadcastTransaction(tx);
-};
+/*
+ *ChainStateProvider.prototype.broadcastTransaction = (chain, network , tx) => {
+ *  return this.get(chain).broadcastTransaction(tx);
+ *};
+ */
 
 module.exports = new ChainStateProvider();

--- a/lib/providers/chain-state/index.js
+++ b/lib/providers/chain-state/index.js
@@ -61,7 +61,7 @@ ChainStateProvider.prototype.getWalletTransactions = async function (chain, netw
 };
 
 ChainStateProvider.prototype.getWalletBalance = async function (chain, network, walletId) {
-  return this.get(chain).getWalletBalance(walletId);
+  return this.get(chain).getWalletBalance(network, walletId);
 };
 
 ChainStateProvider.prototype.getWalletUtxos = async function (chain, network, walletId) {

--- a/lib/providers/index.js
+++ b/lib/providers/index.js
@@ -1,0 +1,5 @@
+const ChainState = require('./chain-state');
+
+module.exports = {
+  ChainState
+};

--- a/lib/routes/address.js
+++ b/lib/routes/address.js
@@ -1,15 +1,15 @@
-const router = require('express').Router();
+const router = require('express').Router({mergeParams: true});
 const ChainStateProvider = require('../providers/chain-state');
 
 router.get('/:address', function(req, res) {
-  let { address } = req.params;
-  let { chain, network, unspent } = req.query;
+  let { address, chain, network } = req.params;
+  console.log(req.params, req.query);
+  let { unspent } = req.query;
   ChainStateProvider.getAddressUtxos(chain, network, address, res, {unspent});
 });
 
 router.get('/:address/balance', async function(req, res) {
-  let { address } = req.params;
-  let { chain, network } = req.query;
+  let { address, chain, network } = req.params;
   try {
     let result = await ChainStateProvider.getBalanceForAddress(chain, network, address);
     res.send(result && result[0] || {balance: 0});

--- a/lib/routes/address.js
+++ b/lib/routes/address.js
@@ -14,7 +14,6 @@ router.get('/:address/balance', async function(req, res) {
   let result = await ChainStateProvider.getBalanceForAddress(chain, network, address);
     res.send(result && result[0] || {balance: 0});
   } catch (err) {
-    console.error(err);
     return res.status(500).send(err);
   }
 });

--- a/lib/routes/address.js
+++ b/lib/routes/address.js
@@ -3,7 +3,6 @@ const ChainStateProvider = require('../providers/chain-state');
 
 router.get('/:address', function(req, res) {
   let { address, chain, network } = req.params;
-  console.log(req.params, req.query);
   let { unspent } = req.query;
   ChainStateProvider.getAddressUtxos(chain, network, address, res, {unspent});
 });

--- a/lib/routes/address.js
+++ b/lib/routes/address.js
@@ -1,21 +1,11 @@
 const router = require('express').Router();
-
-const Storage = require('../services/storage');
+const ChainStateProvider = require('../providers/chain-state');
 const Coin = require('../models/coin');
 
 router.get('/:address', function(req, res) {
   let { address } = req.params;
   let { chain, network, unspent } = req.query;
-  if (typeof address !== 'string' || !chain || !network) {
-    return res.status(400).send('Missing required param');
-  }
-  chain = chain.toUpperCase();
-  network = network.toLowerCase();
-  let query = {chain, network, address};
-  if (unspent) {
-    query.spentHeight = { $lt: 0 };
-  }
-  Storage.apiStreamingFind(Coin, query, req.query, res);
+  ChainStateProvider.getAddressUtxos(chain, network, address, res, {unspent});
 });
 
 router.get('/:address/balance', async function(req, res) {

--- a/lib/routes/address.js
+++ b/lib/routes/address.js
@@ -11,7 +11,7 @@ router.get('/:address/balance', async function(req, res) {
   let { address } = req.params;
   let { chain, network } = req.query;
   try {
-  let result = await ChainStateProvider.getBalanceForAddress(chain, network, address);
+    let result = await ChainStateProvider.getBalanceForAddress(chain, network, address);
     res.send(result && result[0] || {balance: 0});
   } catch (err) {
     return res.status(500).send(err);

--- a/lib/routes/address.js
+++ b/lib/routes/address.js
@@ -4,7 +4,7 @@ const ChainStateProvider = require('../providers/chain-state');
 router.get('/:address', function(req, res) {
   let { address, chain, network } = req.params;
   let { unspent } = req.query;
-  ChainStateProvider.getAddressUtxos(chain, network, address, res, {unspent});
+  ChainStateProvider.streamAddressUtxos(chain, network, address, res, {unspent});
 });
 
 router.get('/:address/balance', async function(req, res) {

--- a/lib/routes/address.js
+++ b/lib/routes/address.js
@@ -1,6 +1,5 @@
 const router = require('express').Router();
 const ChainStateProvider = require('../providers/chain-state');
-const Coin = require('../models/coin');
 
 router.get('/:address', function(req, res) {
   let { address } = req.params;
@@ -11,15 +10,8 @@ router.get('/:address', function(req, res) {
 router.get('/:address/balance', async function(req, res) {
   let { address } = req.params;
   let { chain, network } = req.query;
-  if (typeof address !== 'string' || !chain || !network) {
-    return res.status(400).send('Missing required param');
-  }
-  chain = chain.toUpperCase();
-  network = network.toLowerCase();
-  let query = {chain, network, address};
-  let balance = Coin.getBalance({ query });
   try {
-    let result = await balance.exec();
+  let result = await ChainStateProvider.getBalanceForAddress(chain, network, address);
     res.send(result && result[0] || {balance: 0});
   } catch (err) {
     return res.status(500).send(err);

--- a/lib/routes/address.js
+++ b/lib/routes/address.js
@@ -14,6 +14,7 @@ router.get('/:address/balance', async function(req, res) {
   let result = await ChainStateProvider.getBalanceForAddress(chain, network, address);
     res.send(result && result[0] || {balance: 0});
   } catch (err) {
+    console.error(err);
     return res.status(500).send(err);
   }
 });

--- a/lib/routes/block.js
+++ b/lib/routes/block.js
@@ -10,7 +10,6 @@ router.get('/:blockId', async function(req, res) {
     }
     res.json(block);
   } catch (err) {
-    console.log(err);
     return res.status(500).send(err);
   }
 });

--- a/lib/routes/block.js
+++ b/lib/routes/block.js
@@ -1,34 +1,18 @@
-const router = require('express').Router();
+const router = require('express').Router({ mergeParams: true });
+const ChainStateProvider = require('../providers/chain-state');
 
-const Block = require('../models/block');
-
-router.get('/:blockId', function(req, res) {
-  let {blockId} = req.params;
-  let {chain, network} = req.query;
-  if (typeof blockId !== 'string' || !chain || !network){
-    return res.status(400).send('Missing required param');
-  }
-  chain = chain.toUpperCase();
-  network = network.toLowerCase();
-  let query = {chain, network};
-  if (blockId.length === 64){
-    query.hash = blockId;
-  } else {
-    let height = parseInt(blockId, 10);
-    if (Number.isNaN(height) || height.toString(10) !== blockId) {
-      return res.status(400).send('invalid block id provided');
-    }
-    query.height = height;
-  }
-  Block.findOne(query, function(err, block){
-    if(err){
-      return res.status(500).send(err);
-    }
-    if(!block) {
+router.get('/:blockId', async function(req, res) {
+  let { blockId, chain, network } = req.params;
+  try {
+    let block = await ChainStateProvider.getBlock(chain, network, blockId);
+    if (!block) {
       return res.status(404).send('block not found');
     }
-    res.json(Block._apiTransform(block,{object:true}));
-  });
+    res.json(block);
+  } catch (err) {
+    console.log(err);
+    return res.status(500).send(err);
+  }
 });
 
 module.exports = {

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -17,6 +17,7 @@ function bootstrap(app) {
     }
   });
 
+  console.log(app);
   app.use((req, resp, next) => {
     let { chain, network } = req.query;
     const hasChain = chains.includes(chain);

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -17,7 +17,6 @@ function bootstrap(app) {
     }
   });
 
-  console.log(app);
   app.use((req, resp, next) => {
     let { chain, network } = req.query;
     const hasChain = chains.includes(chain);

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -10,10 +10,9 @@ const chains = Object.keys(config.chains);
 const networks = {};
 for (let chain of chains) {
   for (let network of Object.keys(config.chains[chain])) {
-    Object.assign(networks, {
-      [chain]: {
+    networks[chain] = networks[chain] || {};
+    Object.assign(networks[chain], {
         [network]: true
-      }
     });
   }
 }

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -1,6 +1,6 @@
 function bootstrap(app) {
   const fs = require('fs');
-  const router = require('express').Router();
+  const router = require('express').Router({mergeParams: true});
   const config = require('../config');
   const chains = Object.keys(config.chains);
   const networks = {};
@@ -18,7 +18,7 @@ function bootstrap(app) {
   });
 
   app.use((req, resp, next) => {
-    let { chain, network } = req.query;
+    let { chain, network } = req.params;
     const hasChain = chains.includes(chain);
     const chainNetworks = networks[chain] || null;
     const hasChainNetworks = chainNetworks != null;
@@ -32,6 +32,7 @@ function bootstrap(app) {
     }
     next();
   });
+
   return router;
 }
 

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -1,16 +1,31 @@
+const express = require('express');
+const app = express();
+const bodyParser = require('body-parser');
+app.use(bodyParser.json());
+app.use(bodyParser.raw({
+  limit: 100000000
+}));
+
+
 function bootstrap(app) {
   const fs = require('fs');
-  const router = require('express').Router({mergeParams: true});
+  const router = require('express').Router({
+    mergeParams: true
+  });
   const config = require('../config');
   const chains = Object.keys(config.chains);
   const networks = {};
   for (let chain of chains) {
     for (let network of Object.keys(config.chains[chain])) {
-      Object.assign(networks, { [chain]: { [network]: true } });
+      Object.assign(networks, {
+        [chain]: {
+          [network]: true
+        }
+      });
     }
   }
 
-  fs.readdirSync(__dirname + '/').forEach(function (file) {
+  fs.readdirSync(__dirname + '/').forEach(function(file) {
     if (file.match(/\.js$/) !== null && file !== 'index.js') {
       var route = require('./' + file);
       router.use(route.path, route.router);
@@ -18,7 +33,10 @@ function bootstrap(app) {
   });
 
   app.use((req, resp, next) => {
-    let { chain, network } = req.params;
+    let {
+      chain,
+      network
+    } = req.params;
     const hasChain = chains.includes(chain);
     const chainNetworks = networks[chain] || null;
     const hasChainNetworks = chainNetworks != null;
@@ -36,5 +54,6 @@ function bootstrap(app) {
   return router;
 }
 
+app.use('/api/:chain/:network', bootstrap(app));
 
-module.exports = bootstrap;
+module.exports = app;

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -5,26 +5,24 @@ app.use(bodyParser.json());
 app.use(bodyParser.raw({
   limit: 100000000
 }));
+const config = require('../config');
+const chains = Object.keys(config.chains);
+const networks = {};
+for (let chain of chains) {
+  for (let network of Object.keys(config.chains[chain])) {
+    Object.assign(networks, {
+      [chain]: {
+        [network]: true
+      }
+    });
+  }
+}
 
-
-function bootstrap(app) {
+function bootstrap() {
   const fs = require('fs');
-  const router = require('express').Router({
+  const router = express.Router({
     mergeParams: true
   });
-  const config = require('../config');
-  const chains = Object.keys(config.chains);
-  const networks = {};
-  for (let chain of chains) {
-    for (let network of Object.keys(config.chains[chain])) {
-      Object.assign(networks, {
-        [chain]: {
-          [network]: true
-        }
-      });
-    }
-  }
-
   fs.readdirSync(__dirname + '/').forEach(function(file) {
     if (file.match(/\.js$/) !== null && file !== 'index.js') {
       var route = require('./' + file);
@@ -32,28 +30,27 @@ function bootstrap(app) {
     }
   });
 
-  app.use((req, resp, next) => {
-    let {
-      chain,
-      network
-    } = req.params;
-    const hasChain = chains.includes(chain);
-    const chainNetworks = networks[chain] || null;
-    const hasChainNetworks = chainNetworks != null;
-    const hasNetworkForChain = hasChainNetworks ? chainNetworks[network] : false;
-
-    if (chain && !hasChain) {
-      return resp.status(500).send(`This node is not configured for the chain ${chain}`);
-    }
-    if (network && (!hasChainNetworks || !hasNetworkForChain)) {
-      return resp.status(500).send(`This node is not configured for the network ${network} on chain ${chain}`);
-    }
-    next();
-  });
-
   return router;
 }
+app.use('/api/:chain/:network', (req, resp, next) => {
+  let {
+    chain,
+    network
+  } = req.params;
+  const hasChain = chains.includes(chain);
+  const chainNetworks = networks[chain] || null;
+  const hasChainNetworks = chainNetworks != null;
+  const hasNetworkForChain = hasChainNetworks ? chainNetworks[network] : false;
 
-app.use('/api/:chain/:network', bootstrap(app));
+  if (chain && !hasChain) {
+    return resp.status(500).send(`This node is not configured for the chain ${chain}`);
+  }
+  if (network && (!hasChainNetworks || !hasNetworkForChain)) {
+    return resp.status(500).send(`This node is not configured for the network ${network} on chain ${chain}`);
+  }
+  next();
+});
+
+app.use('/api/:chain/:network', bootstrap());
 
 module.exports = app;

--- a/lib/routes/tx.js
+++ b/lib/routes/tx.js
@@ -1,7 +1,5 @@
 const router = require('express').Router({mergeParams: true});
-const JSONStream = require('JSONStream');
-
-const Transaction = require('../models/transaction');
+const ChainStateProvider = require('../providers/chain-state');
 
 router.get('/', function(req, res) {
   let { chain, network } = req.params;
@@ -17,7 +15,7 @@ router.get('/', function(req, res) {
   if(req.query.blockHash) {
     query.blockHash = req.query.blockHash;
   }
-  Transaction.getTransactions({ query }).pipe(JSONStream.stringify()).pipe(res);
+  ChainStateProvider.streamTransactions(chain, network, res, query);
 });
 
 router.get('/:txid', function(req, res) {
@@ -27,8 +25,7 @@ router.get('/:txid', function(req, res) {
   }
   chain = chain.toUpperCase();
   network = network.toLowerCase();
-  let query = {chain, network, txid: req.params.txid};
-  Transaction.getTransactions({ query }).pipe(JSONStream.stringify()).pipe(res);
+  ChainStateProvider.streamTransaction(chain, network, txid, res);
 });
 module.exports = {
   router: router,

--- a/lib/routes/tx.js
+++ b/lib/routes/tx.js
@@ -1,10 +1,10 @@
-const router = require('express').Router();
+const router = require('express').Router({mergeParams: true});
 const JSONStream = require('JSONStream');
 
 const Transaction = require('../models/transaction');
 
 router.get('/', function(req, res) {
-  let { chain, network } = req.query;
+  let { chain, network } = req.params;
   if (!chain || !network) {
     return res.status(400).send('Missing required param');
   }
@@ -21,7 +21,7 @@ router.get('/', function(req, res) {
 });
 
 router.get('/:txid', function(req, res) {
-  let { chain, network } = req.query;
+  let { chain, network, txid } = req.params;
   if (typeof txid !== 'string' || !chain || !network) {
     return res.status(400).send('Missing required param');
   }

--- a/lib/routes/wallet.js
+++ b/lib/routes/wallet.js
@@ -51,31 +51,32 @@ router.get('/:walletId/addresses', async function(req, res) {
   try {
     let {walletId} = req.params;
     let {chain, network} = req.query;
-    let wallet = await Wallet.findOne({ _id: req.params.walletId }).exec();
+    let wallet = await ChainStateProvider.getWallet(chain, network, walletId);
     if (!wallet) {
       return res.status(404).send(new Error('Wallet not found'));
     }
     ChainStateProvider.getWalletAddresses(chain, network, walletId, res);
   } catch (err) {
-    console.error(err);
     return res.status(500).send(err);
   }
 });
 
 // update wallet
 router.post('/:walletId', async (req, res) => {
-  let wallet = await Wallet.findOne({ _id: req.params.walletId }).exec();
-  if (!wallet) {
-    return res.status(404).send(new Error('Wallet not found'));
-  }
-
-  let addresses = req.body.toString().split('\n')
-    .filter((json) => json!= '')
-    .map(JSON.parse)
-    .map((line) => line.address)
-    .filter((address) => address != null);
-
+  let {walletId} = req.params;
+  let {chain, network} = req.query;
   try {
+    let wallet = await ChainStateProvider.getWallet(chain, network, walletId);
+    if (!wallet) {
+      return res.status(404).send(new Error('Wallet not found'));
+    }
+
+    let addresses = req.body.toString().split('\n')
+      .filter((json) => json!= '')
+      .map(JSON.parse)
+      .map((line) => line.address)
+      .filter((address) => address != null);
+
     await WalletAddress.updateCoins(wallet, addresses);
     return res.send({ success: true });
   } catch (err) {
@@ -170,7 +171,7 @@ router.get('/:walletId/transactions', async (req, res) => {
   let {walletId} = req.params;
   let {chain, network} = req.query;
   try {
-    let wallet = await Wallet.findOne({ _id: req.params.walletId }).exec();
+    let wallet = await ChainStateProvider.getWallet(chain, network, walletId);
     if (!wallet) {
       return res.status(404).send(new Error('Wallet not found'));
     }

--- a/lib/routes/wallet.js
+++ b/lib/routes/wallet.js
@@ -43,19 +43,19 @@ router.get('/:walletId', async function(req, res) {
     }
     res.send(wallet);
   } catch (err){
-    console.error(err);
     return res.status(500).send(err);
   }
 });
 
 router.get('/:walletId/addresses', async function(req, res) {
   try {
+    let {walletId} = req.params;
+    let {chain, network} = req.query;
     let wallet = await Wallet.findOne({ _id: req.params.walletId }).exec();
     if (!wallet) {
       return res.status(404).send(new Error('Wallet not found'));
     }
-    let query = { wallet: wallet._id };
-    Storage.apiStreamingFind(WalletAddress, query, req.query, res);
+    ChainStateProvider.getWalletAddresses(chain, network, walletId, res);
   } catch (err) {
     return res.status(500).send(err);
   }

--- a/lib/routes/wallet.js
+++ b/lib/routes/wallet.js
@@ -176,7 +176,6 @@ router.get('/:walletId/transactions', async (req, res) => {
     }
     ChainStateProvider.getWalletTransactions(chain, network, walletId, res);
   } catch(err) {
-    console.error(err);
     return res.status(500).send(err);
   }
 });

--- a/lib/routes/wallet.js
+++ b/lib/routes/wallet.js
@@ -196,15 +196,17 @@ router.get('/:walletId/balance', async (req, res) => {
 });
 
 router.get('/:walletId/utxos', async (req, res) => {
-  let wallet = await Wallet.findOne({ _id: req.params.walletId }).exec();
-  if (!wallet) {
-    return res.status(404).send(new Error('Wallet not found'));
+  let {chain, network} = req.query;
+  let {walletId} = req.params;
+  try{
+    let wallet = await ChainStateProvider.getWallet(chain, network, walletId);
+    if (!wallet) {
+      return res.status(404).send(new Error('Wallet not found'));
+    }
+    ChainStateProvider.getWalletUtxos(chain, network, walletId, res, req.params);
+  }catch (err){
+    return res.status(500).send(err);
   }
-  let query = { wallets: wallet._id, spentHeight: {$lt: 0} };
-  if (req.params.spent){
-    query.spentHeight = { $gt: 0 };
-  }
-  Storage.apiStreamingFind(Coin, query, req.query, res);
 });
 
 module.exports = {

--- a/lib/routes/wallet.js
+++ b/lib/routes/wallet.js
@@ -181,14 +181,14 @@ router.get('/:walletId/transactions', async (req, res) => {
 });
 
 router.get('/:walletId/balance', async (req, res) => {
-  let wallet = await Wallet.findOne({ _id: req.params.walletId }).exec();
-  if (!wallet) {
-    return res.status(404).send(new Error('Wallet not found'));
-  }
-  let query = { wallets: wallet._id };
-  let balance = Coin.getBalance({query});
-  try {
-    let result = await balance.exec();
+  let {chain, network} = req.query;
+  let {walletId} = req.params;
+  try{
+    let wallet = await ChainStateProvider.getWallet(chain, network, walletId);
+    if (!wallet) {
+      return res.status(404).send(new Error('Wallet not found'));
+    }
+    let result = await ChainStateProvider.getWalletBalance(chain, network, walletId);
     res.send(result && result[0] || { balance: 0 });
   } catch (err){
     return res.status(500).send(err);

--- a/lib/routes/wallet.js
+++ b/lib/routes/wallet.js
@@ -1,36 +1,21 @@
 const util = require('util');
 const {Transform} = require('stream');
-
 const router = require('express').Router();
 const _ = require('underscore');
-const mongoose = require('mongoose');
 
 const logger = require('../logger');
 const ChainStateProvider = require('../providers/chain-state');
-const Storage = require('../services/storage');
-const Wallet = mongoose.model('Wallet');
-const WalletAddress = mongoose.model('WalletAddress');
-const Transaction = mongoose.model('Transaction');
-const Coin = mongoose.model('Coin');
 
 // create wallet
-router.post('/', function(req, res) {
+router.post('/', async function(req, res) {
   let {chain, network, name, pubKey, path} = req.body;
-  if (typeof name !== 'string' || !chain || !network) {
-    return res.status(400).send('Missing required param');
-  }
-  Wallet.create({
-    chain,
-    network,
-    name,
-    pubKey,
-    path
-  }, function(err, result) {
-    if(err) {
-      res.status(500).send(err);
-    }
+  try {
+    let result = await ChainStateProvider.createWallet(chain, network, name, pubKey, {path});
     res.send(result);
-  });
+  }
+  catch(err) {
+    res.status(500).send(err);
+  }
 });
 
 router.get('/:walletId', async function(req, res) {
@@ -77,7 +62,7 @@ router.post('/:walletId', async (req, res) => {
       .map((line) => line.address)
       .filter((address) => address != null);
 
-    await WalletAddress.updateCoins(wallet, addresses);
+    await ChainStateProvider.updateWallet(chain, network, walletId, addresses);
     return res.send({ success: true });
   } catch (err) {
     return res.status(500).send(err);

--- a/lib/routes/wallet.js
+++ b/lib/routes/wallet.js
@@ -1,6 +1,6 @@
 const util = require('util');
 const {Transform} = require('stream');
-const router = require('express').Router();
+const router = require('express').Router({mergeParams: true});
 const _ = require('underscore');
 
 const logger = require('../logger');
@@ -20,8 +20,7 @@ router.post('/', async function(req, res) {
 
 router.get('/:walletId', async function(req, res) {
   try {
-    let {walletId} = req.params;
-    let {chain, network} = req.query;
+    let {chain, network, walletId} = req.params;
     let wallet = await ChainStateProvider.getWallet(chain, network, walletId);
     if (!wallet) {
       return res.status(404).send(new Error('Wallet not found'));
@@ -34,8 +33,7 @@ router.get('/:walletId', async function(req, res) {
 
 router.get('/:walletId/addresses', async function(req, res) {
   try {
-    let {walletId} = req.params;
-    let {chain, network} = req.query;
+    let {chain, network, walletId} = req.params;
     let wallet = await ChainStateProvider.getWallet(chain, network, walletId);
     if (!wallet) {
       return res.status(404).send(new Error('Wallet not found'));
@@ -48,8 +46,7 @@ router.get('/:walletId/addresses', async function(req, res) {
 
 // update wallet
 router.post('/:walletId', async (req, res) => {
-  let {walletId} = req.params;
-  let {chain, network} = req.query;
+  let {chain, network, walletId} = req.params;
   try {
     let wallet = await ChainStateProvider.getWallet(chain, network, walletId);
     if (!wallet) {
@@ -153,22 +150,20 @@ ListTransactionsStream.prototype._transform = function(transaction, enc, done) {
 };
 
 router.get('/:walletId/transactions', async (req, res) => {
-  let {walletId} = req.params;
-  let {chain, network} = req.query;
+  let {walletId, chain, network} = req.params; 
   try {
     let wallet = await ChainStateProvider.getWallet(chain, network, walletId);
     if (!wallet) {
       return res.status(404).send(new Error('Wallet not found'));
     }
-    ChainStateProvider.getWalletTransactions(chain, network, walletId, res);
+    await ChainStateProvider.getWalletTransactions(chain, network, walletId, res, req.query);
   } catch(err) {
     return res.status(500).send(err);
   }
 });
 
 router.get('/:walletId/balance', async (req, res) => {
-  let {chain, network} = req.query;
-  let {walletId} = req.params;
+  let {chain, network, walletId} = req.params;
   try{
     let wallet = await ChainStateProvider.getWallet(chain, network, walletId);
     if (!wallet) {
@@ -182,8 +177,7 @@ router.get('/:walletId/balance', async (req, res) => {
 });
 
 router.get('/:walletId/utxos', async (req, res) => {
-  let {chain, network} = req.query;
-  let {walletId} = req.params;
+  let {chain, network, walletId} = req.params;
   try{
     let wallet = await ChainStateProvider.getWallet(chain, network, walletId);
     if (!wallet) {

--- a/lib/routes/wallet.js
+++ b/lib/routes/wallet.js
@@ -6,6 +6,7 @@ const _ = require('underscore');
 const mongoose = require('mongoose');
 
 const logger = require('../logger');
+const ChainStateProvider = require('../providers/chain-state');
 const Storage = require('../services/storage');
 const Wallet = mongoose.model('Wallet');
 const WalletAddress = mongoose.model('WalletAddress');
@@ -34,12 +35,15 @@ router.post('/', function(req, res) {
 
 router.get('/:walletId', async function(req, res) {
   try {
-    let wallet = await Wallet.findOne({ _id: req.params.walletId }).exec();
+    let {walletId} = req.params;
+    let {chain, network} = req.query;
+    let wallet = await ChainStateProvider.getWallet(chain, network, walletId);
     if (!wallet) {
       return res.status(404).send(new Error('Wallet not found'));
     }
-    res.send(Wallet._apiTransform(wallet));
+    res.send(wallet);
   } catch (err){
+    console.error(err);
     return res.status(500).send(err);
   }
 });

--- a/lib/routes/wallet.js
+++ b/lib/routes/wallet.js
@@ -57,6 +57,7 @@ router.get('/:walletId/addresses', async function(req, res) {
     }
     ChainStateProvider.getWalletAddresses(chain, network, walletId, res);
   } catch (err) {
+    console.error(err);
     return res.status(500).send(err);
   }
 });
@@ -166,30 +167,18 @@ ListTransactionsStream.prototype._transform = function(transaction, enc, done) {
 };
 
 router.get('/:walletId/transactions', async (req, res) => {
-  let wallet = await Wallet.findOne({ _id: req.params.walletId }).exec();
-  if (!wallet) {
-    return res.status(404).send(new Error('Wallet not found'));
+  let {walletId} = req.params;
+  let {chain, network} = req.query;
+  try {
+    let wallet = await Wallet.findOne({ _id: req.params.walletId }).exec();
+    if (!wallet) {
+      return res.status(404).send(new Error('Wallet not found'));
+    }
+    ChainStateProvider.getWalletTransactions(chain, network, walletId, res);
+  } catch(err) {
+    console.error(err);
+    return res.status(500).send(err);
   }
-  var query = {
-    wallets: wallet._id
-  };
-  if (req.query.startBlock) {
-    query.blockHeight = { $gte: parseInt(req.query.startBlock) };
-  }
-  if (req.query.endBlock) {
-    query.blockHeight = query.blockHeight || {};
-    query.blockHeight.$lte = parseInt(req.query.endBlock);
-  }
-  if (req.query.startDate) {
-    query.blockTimeNormalized = { $gte: new Date(req.query.startDate) };
-  }
-  if (req.query.endDate) {
-    query.blockTimeNormalized = query.blockTimeNormalized || {};
-    query.blockTimeNormalized.$lt = new Date(req.query.endDate);
-  }
-  var transactionStream = Transaction.getTransactions({query});
-  var listTransactionsStream = new ListTransactionsStream(wallet._id);
-  transactionStream.pipe(listTransactionsStream).pipe(res);
 });
 
 router.get('/:walletId/balance', async (req, res) => {

--- a/lib/routes/wallet.js
+++ b/lib/routes/wallet.js
@@ -38,7 +38,7 @@ router.get('/:walletId/addresses', async function(req, res) {
     if (!wallet) {
       return res.status(404).send(new Error('Wallet not found'));
     }
-    ChainStateProvider.getWalletAddresses(chain, network, walletId, res);
+    ChainStateProvider.streamWalletAddresses(chain, network, walletId, res);
   } catch (err) {
     return res.status(500).send(err);
   }
@@ -156,7 +156,7 @@ router.get('/:walletId/transactions', async (req, res) => {
     if (!wallet) {
       return res.status(404).send(new Error('Wallet not found'));
     }
-    await ChainStateProvider.getWalletTransactions(chain, network, walletId, res, req.query);
+    await ChainStateProvider.streamWalletTransactions(chain, network, walletId, res, req.query);
   } catch(err) {
     return res.status(500).send(err);
   }
@@ -183,7 +183,7 @@ router.get('/:walletId/utxos', async (req, res) => {
     if (!wallet) {
       return res.status(404).send(new Error('Wallet not found'));
     }
-    ChainStateProvider.getWalletUtxos(chain, network, walletId, res, req.params);
+    ChainStateProvider.streamWalletUtxos(chain, network, walletId, res, req.params);
   }catch (err){
     return res.status(500).send(err);
   }

--- a/lib/services/p2p.js
+++ b/lib/services/p2p.js
@@ -240,7 +240,7 @@ P2pService.prototype.getBlock = function(hash, callback) {
 };
 
 P2pService.prototype.processBlock = function(block, callback) {
-  Block.addBlock(block, function(err) {
+  Block.addBlock({chain: this.chain, network: this.network, block}, function(err) {
     if(err){
       logger.error(err);
     } else {

--- a/lib/services/storage.js
+++ b/lib/services/storage.js
@@ -2,11 +2,12 @@ const mongoose = require('mongoose');
 const config = require('../config');
 require('../models');
 
-const StorageService = function(){
-};
+const StorageService = function() {};
 
-StorageService.prototype.start = function(ready) {
-  mongoose.connect(`mongodb://${config.dbHost}/${config.dbName}?socketTimeoutMS=3600000&noDelay=true`, {
+StorageService.prototype.start = function(ready, args) {
+  let options = Object.assign({}, args, config);
+  let { dbName, dbHost } = options;
+  mongoose.connect(`mongodb://${dbHost}/${dbName}?socketTimeoutMS=3600000&noDelay=true`, {
     keepAlive: true,
     poolSize: config.maxPoolSize,
     'native_parser': true
@@ -17,24 +18,26 @@ StorageService.prototype.stop = function() {
 
 };
 
-StorageService.prototype.apiStreamingFind = function(model,query,res){
-  let cursor = model.find(query).cursor({transform: model._apiTransform});
+StorageService.prototype.apiStreamingFind = function(model, query, res) {
+  let cursor = model.find(query).cursor({
+    transform: model._apiTransform
+  });
   cursor.on('error', function(err) {
     return res.status(500).end(err.message);
   });
   let isFirst = true;
   res.type('json');
-  cursor.on('data', function(data){
-    if(isFirst){
+  cursor.on('data', function(data) {
+    if (isFirst) {
       res.write('[\n');
       isFirst = false;
-    } else{
+    } else {
       res.write(',\n');
     }
     res.write(data);
   });
-  cursor.on('end', function(){
-    if(isFirst) {
+  cursor.on('end', function() {
+    if (isFirst) {
       // there was no data
       res.write('[]');
     } else {

--- a/lib/services/storage.js
+++ b/lib/services/storage.js
@@ -1,10 +1,6 @@
 const mongoose = require('mongoose');
 const config = require('../config');
-require('../models/coin');
-require('../models/walletAddress');
-require('../models/transaction');
-require('../models/wallet');
-require('../models/block');
+require('../models');
 
 const StorageService = function(){
 };
@@ -21,7 +17,7 @@ StorageService.prototype.stop = function() {
 
 };
 
-StorageService.prototype.apiStreamingFind = function(model,query,params,res){
+StorageService.prototype.apiStreamingFind = function(model,query,res){
   let cursor = model.find(query).cursor({transform: model._apiTransform});
   cursor.on('error', function(err) {
     return res.status(500).end(err.message);

--- a/package-lock.json
+++ b/package-lock.json
@@ -133,6 +133,11 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "attempt-x": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/attempt-x/-/attempt-x-1.1.3.tgz",
+      "integrity": "sha512-y/+ek8IjxVpTbj/phC87jK5YRhlP5Uu7FlQdCmYuut1DTjNruyrGqUWi5bcX1VKsQX1B0FX16A1hqHomKpHv3A=="
+    },
     "aws-sign2": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
@@ -194,7 +199,7 @@
         },
         "elliptic": {
           "version": "6.3.2",
-          "resolved": "http://registry.npmjs.org/elliptic/-/elliptic-6.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.2.tgz",
           "integrity": "sha1-5MgeCCnPCmWrcOmYuCMnI7XBvEg=",
           "requires": {
             "bn.js": "4.11.6",
@@ -202,6 +207,11 @@
             "hash.js": "1.1.3",
             "inherits": "2.0.3"
           }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
     },
@@ -267,11 +277,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
         }
       }
     },
@@ -291,11 +296,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
         }
       }
     },
@@ -337,9 +337,12 @@
           "resolved": "https://registry.npmjs.org/buffer-compare/-/buffer-compare-1.0.0.tgz",
           "integrity": "sha1-rKp6lm6Y7un64Usxw5pfFY+zxKI="
         },
+        "buffers": {
+          "version": "github:bitpay/node-buffers#04f4c4264e0d105db2b99b786843ed64f23230d8"
+        },
         "elliptic": {
           "version": "3.0.3",
-          "resolved": "http://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
           "integrity": "sha1-hlybQgv75VAGuflp+XoNLESWZZU=",
           "requires": {
             "bn.js": "2.0.4",
@@ -367,44 +370,19 @@
         "bloom-filter": "0.2.0",
         "buffers": "github:bitpay/node-buffers#04f4c4264e0d105db2b99b786843ed64f23230d8",
         "socks5-client": "0.3.6"
+      },
+      "dependencies": {
+        "buffers": {
+          "version": "github:bitpay/node-buffers#04f4c4264e0d105db2b99b786843ed64f23230d8"
+        }
       }
     },
     "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "requires": {
-        "readable-stream": "2.3.5",
-        "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-        },
-        "readable-stream": {
-          "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
+        "readable-stream": "2.0.6"
       }
     },
     "blob": {
@@ -503,6 +481,14 @@
         "evp_bytestokey": "1.0.3",
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "optional": true
+        }
       }
     },
     "bs58": {
@@ -514,9 +500,9 @@
       }
     },
     "bson": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.6.tgz",
-      "integrity": "sha512-D8zmlb46xfuK2gGvKmUjIklQEouN2nQ0LEHHeZ/NoHM2LDiMk2EYzZ5Ntw/Urk+bgMDosOZxaRzXxvhI5TcAVQ=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
+      "integrity": "sha1-k8ENOeqltYQVy8QFLz5T5WKwtyw="
     },
     "buffer-compare": {
       "version": "1.1.1",
@@ -524,18 +510,18 @@
       "integrity": "sha1-W+e+hTr4kZjR9N3AkNHWakiu9ZY="
     },
     "buffer-from": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
-      "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.1.tgz",
+      "integrity": "sha1-V7GLHaChnsBvM4N6UnWiQjUb114=",
+      "requires": {
+        "is-array-buffer-x": "1.7.0"
+      }
     },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "optional": true
-    },
-    "buffers": {
-      "version": "github:bitpay/node-buffers#04f4c4264e0d105db2b99b786843ed64f23230d8"
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -547,6 +533,11 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
       "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
+    },
+    "cached-constructors-x": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cached-constructors-x/-/cached-constructors-x-1.0.2.tgz",
+      "integrity": "sha512-7lKwmwXweW6E/31RHAJemLtZPfb2xvcABXknFF4b/dNYv4DbSGTgQHckXLQkNw6BB4HKFYW6mJgsNjADAy1ehw=="
     },
     "callsite": {
       "version": "1.0.0",
@@ -571,6 +562,13 @@
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
       }
     },
     "cli": {
@@ -788,7 +786,14 @@
         "cipher-base": "1.0.4",
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
-        "sha.js": "2.4.11"
+        "sha.js": "2.4.10"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
       }
     },
     "create-hmac": {
@@ -802,7 +807,15 @@
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
-        "sha.js": "2.4.11"
+        "sha.js": "2.4.10"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "optional": true
+        }
       }
     },
     "cryptiles": {
@@ -823,7 +836,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.41"
+        "es5-ext": "0.10.39"
       }
     },
     "dashdash": {
@@ -936,6 +949,11 @@
         "readable-stream": "1.1.14"
       },
       "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -980,6 +998,13 @@
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.0",
         "minimalistic-crypto-utils": "1.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
       }
     },
     "enabled": {
@@ -1159,13 +1184,12 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.41",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.41.tgz",
-      "integrity": "sha512-MYK02wXfwTMie5TEJWPolgOsXEmz7wKCQaGzgmRjZOoV6VLG8I5dSv2bn6AOClXhK64gnSQTQ9W9MKvx87J4gw==",
+      "version": "0.10.39",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.39.tgz",
+      "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
       "requires": {
         "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1",
-        "next-tick": "1.0.0"
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-iterator": {
@@ -1174,7 +1198,7 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41",
+        "es5-ext": "0.10.39",
         "es6-symbol": "3.1.1"
       }
     },
@@ -1189,7 +1213,7 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41"
+        "es5-ext": "0.10.39"
       }
     },
     "escape-html": {
@@ -1658,6 +1682,29 @@
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
       "optional": true
     },
+    "has-own-property-x": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz",
+      "integrity": "sha512-HtRQTYpRFz/YVaQ7jh2mU5iorMAxFcML9FNOLMI1f8VNJ2K0hpOlXoi1a+nmVl6oUcGnhd6zYOFAVe7NUFStyQ==",
+      "requires": {
+        "cached-constructors-x": "1.0.2",
+        "to-object-x": "1.5.0",
+        "to-property-key-x": "2.0.2"
+      }
+    },
+    "has-symbol-support-x": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "requires": {
+        "has-symbol-support-x": "1.4.2"
+      }
+    },
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -1669,6 +1716,13 @@
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "requires": {
         "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
       }
     },
     "hash.js": {
@@ -1678,6 +1732,13 @@
       "requires": {
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
       }
     },
     "hasha": {
@@ -1747,7 +1808,7 @@
       "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-2.1.3.tgz",
       "integrity": "sha512-fUuDOrB47PqNK/BAMOS13v41UoaqIxqSLHX6CAbOD7OfT+/GCWO1/vPLfTNutOeXrv1ikuaZ3yux+33Z9vh+rw==",
       "requires": {
-        "buffer-from": "0.1.2",
+        "buffer-from": "0.1.1",
         "duplexer2": "0.0.2",
         "through2": "0.6.5"
       }
@@ -1761,6 +1822,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+    },
+    "infinity-x": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/infinity-x/-/infinity-x-1.0.2.tgz",
+      "integrity": "sha512-2Ioz+exrAwlHxFBaDHQIbvUyjKFt0YjIal34/agfzx738aT1zBQwSU5A8Zgb1IQ2r24BtXrkeZZusxE40MyZaQ=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -1797,6 +1863,18 @@
         "sprintf": "0.1.5"
       }
     },
+    "is-array-buffer-x": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/is-array-buffer-x/-/is-array-buffer-x-1.7.0.tgz",
+      "integrity": "sha512-ufSZRMY2WZX5xyNvk0NOZAG7cgi35B/sGQDGqv8w0X7MoQ2GC9vedanJhuYTPaC4PUCqLQsda1w7NF+dPZmAJw==",
+      "requires": {
+        "attempt-x": "1.1.3",
+        "has-to-string-tag-x": "1.4.1",
+        "is-object-like-x": "1.7.1",
+        "object-get-own-property-descriptor-x": "3.2.0",
+        "to-string-tag-x": "1.4.3"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -1812,6 +1890,28 @@
         "builtin-modules": "1.1.1"
       }
     },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+    },
+    "is-falsey-x": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-falsey-x/-/is-falsey-x-1.0.3.tgz",
+      "integrity": "sha512-RWjusR6LXAhGa0Vus7aD1rwJuJwdJsvG3daAVMDvOAgvGuGm4eilNgoSuXhpv2/2qpLDvioAKTNb3t3XYidCNg==",
+      "requires": {
+        "to-boolean-x": "1.0.3"
+      }
+    },
+    "is-finite-x": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.4.tgz",
+      "integrity": "sha512-wdSI5zk/Pl21HzGcLWFoFzuDa8gsgcqhwZGAZryL2eU7RKf7+g+q4jL2gGItrBs/YtspkjOrJ4JxXNZqquoAWA==",
+      "requires": {
+        "infinity-x": "1.0.2",
+        "is-nan-x": "1.0.3"
+      }
+    },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -1820,10 +1920,82 @@
         "number-is-nan": "1.0.1"
       }
     },
+    "is-function-x": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz",
+      "integrity": "sha512-SreSSU1dlgYaXR5c0mm4qJHKYHIiGiEY+7Cd8/aRLLoMP/VvofD2XcWgBnP833ajpU5XzXbUSpfysnfKZLJFlg==",
+      "requires": {
+        "attempt-x": "1.1.3",
+        "has-to-string-tag-x": "1.4.1",
+        "is-falsey-x": "1.0.3",
+        "is-primitive": "2.0.0",
+        "normalize-space-x": "3.0.0",
+        "replace-comments-x": "2.0.0",
+        "to-boolean-x": "1.0.3",
+        "to-string-tag-x": "1.4.3"
+      },
+      "dependencies": {
+        "is-primitive": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+        }
+      }
+    },
+    "is-index-x": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz",
+      "integrity": "sha512-qULKLMepQLGC8rSVdi8uF2vI4LiDrU9XSDg1D+Aa657GIB7GV1jHpga7uXgQvkt/cpQ5mVBHUFTpSehYSqT6+A==",
+      "requires": {
+        "math-clamp-x": "1.2.0",
+        "max-safe-integer": "1.0.1",
+        "to-integer-x": "3.0.0",
+        "to-number-x": "2.0.0",
+        "to-string-symbols-supported-x": "1.0.2"
+      }
+    },
+    "is-nan-x": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-nan-x/-/is-nan-x-1.0.3.tgz",
+      "integrity": "sha512-WenNBLVGSZID8shogsB++42vF7gvotCfneXM9KMCAKwNPXa8VfAu/RWwpqvnK7dLOP4Z7uitocb0TZ6rAiOccA=="
+    },
+    "is-nil-x": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.2.tgz",
+      "integrity": "sha512-9aDY7ir7IGb5HlgqL+b38v2YMxf8S7MEHHxjHGzUhijg2crq47RKdxL37bS6dU0VN87wy2IBZP4akgQtIXmyvg==",
+      "requires": {
+        "lodash.isnull": "3.0.0",
+        "validate.io-undefined": "1.0.3"
+      }
+    },
+    "is-object-like-x": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.7.1.tgz",
+      "integrity": "sha512-89nz+kESAW2Y7udq+PdRX/dZnRN2WP1b19Gdv4OYE1Xjoekn1xf31l0ZPzT40qdPD7I2nveNFm9rxxI0vmnGHA==",
+      "requires": {
+        "is-function-x": "3.3.0",
+        "is-primitive": "3.0.0"
+      }
+    },
+    "is-primitive": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-3.0.0.tgz",
+      "integrity": "sha512-Qch+MMfMdu7DMY6XElM7LUJKPmkbXdTqNhqyehVflzis2a8Zd9V6U8qZybb32uUSmlO/dNmg3fsA5t0Q9TC0mA=="
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-string": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
+      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ="
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1893,7 +2065,7 @@
       "resolved": "https://registry.npmjs.org/jsonist/-/jsonist-2.1.0.tgz",
       "integrity": "sha1-RHek0WzTd/rsWNjPhwt+OS9tf+k=",
       "requires": {
-        "bl": "1.2.2",
+        "bl": "1.2.1",
         "hyperquest": "2.1.3",
         "json-stringify-safe": "5.0.1",
         "xtend": "4.0.1"
@@ -1923,9 +2095,9 @@
       }
     },
     "kareem": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.0.5.tgz",
-      "integrity": "sha512-dfvpj3mCGJLZuADInhYrKaXkGarJxDqnTEiF91wK6fqwdCRmN+O4aEp8575UjZlQzDkzLI1WDL1uU7vyupURqw=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.0.3.tgz",
+      "integrity": "sha512-WloXk3nyByx9FEB5WY7WFEXIZB/QA+zy7c2kJMjnZCebjepEyQcJzazgLiKcTS/ltZeEoeEQ1A1pau1fEDlnIA=="
     },
     "kew": {
       "version": "0.7.0",
@@ -2000,9 +2172,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash.cond": {
       "version": "4.5.2",
@@ -2014,6 +2186,11 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.isnull": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnull/-/lodash.isnull-3.0.0.tgz",
+      "integrity": "sha1-+vvlnqHcon7teGU0A53YTC4HxW4="
     },
     "lodash.pad": {
       "version": "4.5.1",
@@ -2046,6 +2223,28 @@
         }
       }
     },
+    "math-clamp-x": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
+      "integrity": "sha512-tqpjpBcIf9UulApz3EjWXqTZpMlr2vLN9PryC9ghoyCuRmqZaf3JJhPddzgQpJnKLi2QhoFnvKBFtJekAIBSYg==",
+      "requires": {
+        "to-number-x": "2.0.0"
+      }
+    },
+    "math-sign-x": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz",
+      "integrity": "sha512-OzPas41Pn4d16KHnaXmGxxY3/l3zK4OIXtmIwdhgZsxz4FDDcNnbrABYPg2vGfxIkaT9ezGnzDviRH7RfF44jQ==",
+      "requires": {
+        "is-nan-x": "1.0.3",
+        "to-number-x": "2.0.0"
+      }
+    },
+    "max-safe-integer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/max-safe-integer/-/max-safe-integer-1.0.1.tgz",
+      "integrity": "sha1-84BgvixWPYwC5tSK85Ei/YO29BA="
+    },
     "md5.js": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
@@ -2065,6 +2264,11 @@
             "inherits": "2.0.3",
             "safe-buffer": "5.1.1"
           }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
     },
@@ -2139,32 +2343,32 @@
       }
     },
     "mongodb": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.0.4.tgz",
-      "integrity": "sha512-90YIIs7A4ko4kCGafxxXj3foexCAlJBC0YLwwIKgSLoE7Vni2IqUMz6HSsZ3zbXOfR1KWtxfnc0RyAMAY/ViLg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.0.2.tgz",
+      "integrity": "sha512-E50FmpSQchZAimn2uPIegoNoH9UQYR1yiGHtQPmmg8/Ekc97w6owHoqaBoz+assnd9V5LxMzmQ/VEWMsQMgZhQ==",
       "requires": {
-        "mongodb-core": "3.0.4"
+        "mongodb-core": "3.0.2"
       }
     },
     "mongodb-core": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.0.4.tgz",
-      "integrity": "sha512-OTH267FjfwBdEufSnrgd+u8HuLWRuQ6p8DR0XirPl2BdlLEMh4XwjJf1RTlruILp5p2m1w8dDC8rCxibC3W8qQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.0.2.tgz",
+      "integrity": "sha512-p1B0qwFQUw6C1OlFJnrOJp8KaX7MuGoogRbTaupRt0y+pPRkMllHWtE9V6i1CDtTvI3/3sy2sQwqWez7zuXEAA==",
       "requires": {
-        "bson": "1.0.6",
+        "bson": "1.0.4",
         "require_optional": "1.0.1"
       }
     },
     "mongoose": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.0.11.tgz",
-      "integrity": "sha512-VAnMQ356GdQauWJM4KjQh5VuysPv8r+Nm7bKk9F/np3VQwe31B/p6ynQQVmLsTwmkjF5Dqw1pC8Rlg8CCa3rNA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.0.3.tgz",
+      "integrity": "sha512-y4NlLzZaQe5vJHjcEjHLKK6utjs7sVEPN971+d1vVJJGrmA+zeeFA1MEmC1J0ujD34eOSghnExXJPwCrxHHZCw==",
       "requires": {
         "async": "2.1.4",
-        "bson": "1.0.6",
-        "kareem": "2.0.5",
+        "bson": "1.0.4",
+        "kareem": "2.0.3",
         "lodash.get": "4.4.2",
-        "mongodb": "3.0.4",
+        "mongodb": "3.0.2",
         "mongoose-legacy-pluralize": "1.0.2",
         "mpath": "0.3.0",
         "mquery": "3.0.0",
@@ -2178,8 +2382,13 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
           "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
           "requires": {
-            "lodash": "4.17.5"
+            "lodash": "4.17.4"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -2212,6 +2421,11 @@
             "ms": "2.0.0"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
         "sliced": {
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
@@ -2230,6 +2444,11 @@
       "integrity": "sha1-1bAWkSUzJql6K77p5hxV2NYDUeI=",
       "optional": true
     },
+    "nan-x": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nan-x/-/nan-x-1.0.2.tgz",
+      "integrity": "sha512-dndRmy03JQEN+Nh6WjQl7/OstIozeEmrtWe4TE7mEqJ8W8oMD8m2tHjsLPWt//e3hLAeRSbs4pxMyc5pk/nCkQ=="
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -2239,11 +2458,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/network-byte-order/-/network-byte-order-0.2.0.tgz",
       "integrity": "sha1-asEb9Ev2ENrt2+kKCaXIF8bg0rM="
-    },
-    "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "node-abi": {
       "version": "2.3.0",
@@ -2329,6 +2543,16 @@
         "validate-npm-package-license": "3.0.1"
       }
     },
+    "normalize-space-x": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-3.0.0.tgz",
+      "integrity": "sha512-tbCJerqZCCHPst4rRKgsTanLf45fjOyeAU5zE3mhDxJtFJKt66q39g2XArWhXelgTFVib8mNBUm6Wrd0LxYcfQ==",
+      "requires": {
+        "cached-constructors-x": "1.0.2",
+        "trim-x": "3.0.0",
+        "white-space-x": "3.0.1"
+      }
+    },
     "npmlog": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
@@ -2360,6 +2584,30 @@
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "optional": true
+    },
+    "object-get-own-property-descriptor-x": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/object-get-own-property-descriptor-x/-/object-get-own-property-descriptor-x-3.2.0.tgz",
+      "integrity": "sha512-Z/0fIrptD9YuzN+SNK/1kxAEaBcPQM4gSrtOSMSi9eplnL/AbyQcAyAlreAoAzmBon+DQ1Z+AdhxyQSvav5Fyg==",
+      "requires": {
+        "attempt-x": "1.1.3",
+        "has-own-property-x": "3.2.0",
+        "has-symbol-support-x": "1.4.2",
+        "is-falsey-x": "1.0.3",
+        "is-index-x": "1.1.0",
+        "is-primitive": "2.0.0",
+        "is-string": "1.0.4",
+        "property-is-enumerable-x": "1.1.0",
+        "to-object-x": "1.5.0",
+        "to-property-key-x": "2.0.2"
+      },
+      "dependencies": {
+        "is-primitive": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+        }
+      }
     },
     "on-finished": {
       "version": "2.3.0",
@@ -2429,6 +2677,17 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
+    },
+    "parse-int-x": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz",
+      "integrity": "sha512-NIMm52gmd1+0qxJK8lV3OZ4zzWpRH1xcz9xCHXl+DNzddwUdS4NEtd7BmTeK7iCIXoaK5e6BoDMHgieH2eNIhg==",
+      "requires": {
+        "cached-constructors-x": "1.0.2",
+        "nan-x": "1.0.2",
+        "to-string-x": "1.4.5",
+        "trim-left-x": "3.0.0"
+      }
     },
     "parse-json": {
       "version": "2.2.0",
@@ -2593,7 +2852,7 @@
         "npmlog": "2.0.4",
         "os-homedir": "1.0.2",
         "pump": "1.0.3",
-        "rc": "1.2.6",
+        "rc": "1.2.5",
         "simple-get": "1.4.3",
         "tar-fs": "1.16.0",
         "tar-stream": "1.5.5",
@@ -2630,7 +2889,7 @@
         "npmlog": "4.1.2",
         "os-homedir": "1.0.2",
         "pump": "2.0.1",
-        "rc": "1.2.6",
+        "rc": "1.2.5",
         "simple-get": "2.7.0",
         "tar-fs": "1.16.0",
         "tunnel-agent": "0.6.0",
@@ -2704,6 +2963,15 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
     },
+    "property-is-enumerable-x": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/property-is-enumerable-x/-/property-is-enumerable-x-1.1.0.tgz",
+      "integrity": "sha512-22cKy3w3OpRswU6to9iKWDDlg+F9vF2REcwGlGW23jyLjHb1U/jJEWA44sWupOnkhGfDgotU6Lw+N2oyhNi+5A==",
+      "requires": {
+        "to-object-x": "1.5.0",
+        "to-property-key-x": "2.0.2"
+      }
+    },
     "proxy-addr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
@@ -2748,9 +3016,9 @@
       }
     },
     "rc": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
-      "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
+      "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
       "optional": true,
       "requires": {
         "deep-extend": "0.4.2",
@@ -2824,6 +3092,15 @@
       "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
       "integrity": "sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk="
     },
+    "replace-comments-x": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-2.0.0.tgz",
+      "integrity": "sha512-+vMP4jqU+8HboLWms6YMNEiaZG5hh1oR6ENCnGYDF/UQ7aYiJUK/8tcl3+KZAHRCKKa3gqzrfiarlUBHQSgRlg==",
+      "requires": {
+        "require-coercible-to-string-x": "1.0.2",
+        "to-string-x": "1.4.5"
+      }
+    },
     "request": {
       "version": "2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
@@ -2891,6 +3168,23 @@
         "throttleit": "1.0.0"
       }
     },
+    "require-coercible-to-string-x": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/require-coercible-to-string-x/-/require-coercible-to-string-x-1.0.2.tgz",
+      "integrity": "sha512-GZ3BSCL0n/zhho8ITganW9FGPh0Kxhq71nCjck8Qau/30Wf4Po8a3XpQdzEMFiXCwZ/0m0E3lKSdSG8gkcIofQ==",
+      "requires": {
+        "require-object-coercible-x": "1.4.3",
+        "to-string-x": "1.4.5"
+      }
+    },
+    "require-object-coercible-x": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/require-object-coercible-x/-/require-object-coercible-x-1.4.3.tgz",
+      "integrity": "sha512-5wEaS+NIiU5HLJQTqBQ+6XHtX7yplUS374j/H/nRDlc7rMWfENqp026jnUHWAOCZ+ekixkXuFHEnTF28oqqVLA==",
+      "requires": {
+        "is-nil-x": "1.4.2"
+      }
+    },
     "require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
@@ -2929,6 +3223,13 @@
       "requires": {
         "hash-base": "2.0.2",
         "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
       }
     },
     "safe-buffer": {
@@ -3010,12 +3311,19 @@
       "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
     },
     "sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
+      "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
       }
     },
     "signal-exit": {
@@ -3387,7 +3695,7 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "requires": {
-        "bl": "1.2.2",
+        "bl": "1.2.1",
         "end-of-stream": "1.4.1",
         "readable-stream": "2.0.6",
         "xtend": "4.0.1"
@@ -3412,6 +3720,11 @@
         "xtend": "4.0.1"
       },
       "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -3436,12 +3749,138 @@
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
       "optional": true
     },
+    "to-boolean-x": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.3.tgz",
+      "integrity": "sha512-kQiMyJUgFprL8J+0CfgJuaSFKJMs3EvFe27/6aj/hVzVZT0HY4aA1QjPldLNxzBmjhLcapp7CctYHuD8QqtS3g=="
+    },
+    "to-integer-x": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz",
+      "integrity": "sha512-794L2Lpwjtynm7RxahJi2YdbRY75gTxUW27TMuN26UgwPkmJb/+HPhkFEFbz+E4vNoiP0dxq5tq5fkXoXLaK/w==",
+      "requires": {
+        "is-finite-x": "3.0.4",
+        "is-nan-x": "1.0.3",
+        "math-sign-x": "3.0.0",
+        "to-number-x": "2.0.0"
+      }
+    },
+    "to-number-x": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz",
+      "integrity": "sha512-lGOnCoccUoSzjZ/9Uen8TC4+VFaQcFGhTroWTv2tYWxXgyJV1zqAZ8hEIMkez/Eo790fBMOjidTnQ/OJSCvAoQ==",
+      "requires": {
+        "cached-constructors-x": "1.0.2",
+        "nan-x": "1.0.2",
+        "parse-int-x": "2.0.0",
+        "to-primitive-x": "1.1.0",
+        "trim-x": "3.0.0"
+      }
+    },
+    "to-object-x": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/to-object-x/-/to-object-x-1.5.0.tgz",
+      "integrity": "sha512-AKn5GQcdWky+s20vjWkt+Wa6y3dxQH3yQyMBhOfBOPldUwqwhgvlqcIg5H092ntNc+TX8/Cxzs1kMHH19pyCnA==",
+      "requires": {
+        "cached-constructors-x": "1.0.2",
+        "require-object-coercible-x": "1.4.3"
+      }
+    },
+    "to-primitive-x": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-primitive-x/-/to-primitive-x-1.1.0.tgz",
+      "integrity": "sha512-gyMY0gi3wjK3e4MUBKqv9Zl8QGcWguIkaUr2VJmoBEsOpDcpDZSEyljR773eVG4maS48uX7muLkoQoh/BA82OQ==",
+      "requires": {
+        "has-symbol-support-x": "1.4.2",
+        "is-date-object": "1.0.1",
+        "is-function-x": "3.3.0",
+        "is-nil-x": "1.4.2",
+        "is-primitive": "2.0.0",
+        "is-symbol": "1.0.1",
+        "require-object-coercible-x": "1.4.3",
+        "validate.io-undefined": "1.0.3"
+      },
+      "dependencies": {
+        "is-primitive": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+        }
+      }
+    },
+    "to-property-key-x": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/to-property-key-x/-/to-property-key-x-2.0.2.tgz",
+      "integrity": "sha512-YISLpZFYIazNm0P8hLsKEEUEZ3m8U3+eDysJZqTu3+B9tQp+2TrMpaEGT8Agh4fZ5LSoums60/glNEzk5ozqrg==",
+      "requires": {
+        "has-symbol-support-x": "1.4.2",
+        "to-primitive-x": "1.1.0",
+        "to-string-x": "1.4.5"
+      }
+    },
+    "to-string-symbols-supported-x": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/to-string-symbols-supported-x/-/to-string-symbols-supported-x-1.0.2.tgz",
+      "integrity": "sha512-3MRqhIhSNVDsVAk4M6WNcuBZrAQe54W13xrXX6RzxXS+pA4nj6DQ96RegQS5z9BSNyYbFsBsPvMVDIpP+a/5RA==",
+      "requires": {
+        "cached-constructors-x": "1.0.2",
+        "has-symbol-support-x": "1.4.2",
+        "is-symbol": "1.0.1"
+      }
+    },
+    "to-string-tag-x": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.4.3.tgz",
+      "integrity": "sha512-5+0EZ6dOVt/XArXmkooxPzWxmOR081HM/uXitUow7h11WYg5pPo15uYqDWuqO7ZY+O3Atn/dG26wcJCK+mFevg==",
+      "requires": {
+        "lodash.isnull": "3.0.0",
+        "validate.io-undefined": "1.0.3"
+      }
+    },
+    "to-string-x": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/to-string-x/-/to-string-x-1.4.5.tgz",
+      "integrity": "sha512-5xzlZDyDa9BUWNjNzZzHgKQ95PnV7qjvEhbqpFaj1ixaHgfJXOFaa3xdMJ+WLYd4hhaMJaxt8Pt5uKaWXfruXA==",
+      "requires": {
+        "cached-constructors-x": "1.0.2",
+        "is-symbol": "1.0.1"
+      }
+    },
     "tough-cookie": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
       "requires": {
         "punycode": "1.4.1"
+      }
+    },
+    "trim-left-x": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-3.0.0.tgz",
+      "integrity": "sha512-+m6cqkppI+CxQBTwWEZliOHpOBnCArGyMnS1WCLb6IRgukhTkiQu/TNEN5Lj2eM9jk8ewJsc7WxFZfmwNpRXWQ==",
+      "requires": {
+        "cached-constructors-x": "1.0.2",
+        "require-coercible-to-string-x": "1.0.2",
+        "white-space-x": "3.0.1"
+      }
+    },
+    "trim-right-x": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-3.0.0.tgz",
+      "integrity": "sha512-iIqEsWEbWVodqdixJHi4FoayJkUxhoL4AvSNGp4FF4FfQKRPGizt8++/RnyC9od75y7P/S6EfONoVqP+NddiKA==",
+      "requires": {
+        "cached-constructors-x": "1.0.2",
+        "require-coercible-to-string-x": "1.0.2",
+        "white-space-x": "3.0.1"
+      }
+    },
+    "trim-x": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-3.0.0.tgz",
+      "integrity": "sha512-w8s38RAUScQ6t3XqMkS75iz5ZkIYLQpVnv2lp3IuTS36JdlVzC54oe6okOf4Wz3UH4rr3XAb2xR3kR5Xei82fw==",
+      "requires": {
+        "trim-left-x": "3.0.0",
+        "trim-right-x": "3.0.0"
       }
     },
     "triple-beam": {
@@ -3547,6 +3986,11 @@
         "spdx-expression-parse": "1.0.4"
       }
     },
+    "validate.io-undefined": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-undefined/-/validate.io-undefined-1.0.3.tgz",
+      "integrity": "sha1-fif8uzFbhB54JDQxiXZxkp4gt/Q="
+    },
     "vary": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
@@ -3587,6 +4031,11 @@
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "optional": true
+    },
+    "white-space-x": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-3.0.1.tgz",
+      "integrity": "sha512-BwMFXQNPna/4RsNPOgldVYn+FkEv+lc3wUiFzuaW6Z2DH/oSk1UrRD6SBqDgWQO4JU+aBq3PVuPD9Vz0j7mh0w=="
     },
     "wide-align": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -133,11 +133,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
-    "attempt-x": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/attempt-x/-/attempt-x-1.1.3.tgz",
-      "integrity": "sha512-y/+ek8IjxVpTbj/phC87jK5YRhlP5Uu7FlQdCmYuut1DTjNruyrGqUWi5bcX1VKsQX1B0FX16A1hqHomKpHv3A=="
-    },
     "aws-sign2": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
@@ -199,7 +194,7 @@
         },
         "elliptic": {
           "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.2.tgz",
+          "resolved": "http://registry.npmjs.org/elliptic/-/elliptic-6.3.2.tgz",
           "integrity": "sha1-5MgeCCnPCmWrcOmYuCMnI7XBvEg=",
           "requires": {
             "bn.js": "4.11.6",
@@ -207,11 +202,6 @@
             "hash.js": "1.1.3",
             "inherits": "2.0.3"
           }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
     },
@@ -277,6 +267,11 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
         }
       }
     },
@@ -296,6 +291,11 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
         }
       }
     },
@@ -337,12 +337,9 @@
           "resolved": "https://registry.npmjs.org/buffer-compare/-/buffer-compare-1.0.0.tgz",
           "integrity": "sha1-rKp6lm6Y7un64Usxw5pfFY+zxKI="
         },
-        "buffers": {
-          "version": "github:bitpay/node-buffers#04f4c4264e0d105db2b99b786843ed64f23230d8"
-        },
         "elliptic": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
+          "resolved": "http://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
           "integrity": "sha1-hlybQgv75VAGuflp+XoNLESWZZU=",
           "requires": {
             "bn.js": "2.0.4",
@@ -370,19 +367,44 @@
         "bloom-filter": "0.2.0",
         "buffers": "github:bitpay/node-buffers#04f4c4264e0d105db2b99b786843ed64f23230d8",
         "socks5-client": "0.3.6"
-      },
-      "dependencies": {
-        "buffers": {
-          "version": "github:bitpay/node-buffers#04f4c4264e0d105db2b99b786843ed64f23230d8"
-        }
       }
     },
     "bl": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
-        "readable-stream": "2.0.6"
+        "readable-stream": "2.3.5",
+        "safe-buffer": "5.1.1"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "readable-stream": {
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
       }
     },
     "blob": {
@@ -481,14 +503,6 @@
         "evp_bytestokey": "1.0.3",
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
-        }
       }
     },
     "bs58": {
@@ -500,9 +514,9 @@
       }
     },
     "bson": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
-      "integrity": "sha1-k8ENOeqltYQVy8QFLz5T5WKwtyw="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.6.tgz",
+      "integrity": "sha512-D8zmlb46xfuK2gGvKmUjIklQEouN2nQ0LEHHeZ/NoHM2LDiMk2EYzZ5Ntw/Urk+bgMDosOZxaRzXxvhI5TcAVQ=="
     },
     "buffer-compare": {
       "version": "1.1.1",
@@ -510,18 +524,18 @@
       "integrity": "sha1-W+e+hTr4kZjR9N3AkNHWakiu9ZY="
     },
     "buffer-from": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.1.tgz",
-      "integrity": "sha1-V7GLHaChnsBvM4N6UnWiQjUb114=",
-      "requires": {
-        "is-array-buffer-x": "1.7.0"
-      }
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+      "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
     },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "optional": true
+    },
+    "buffers": {
+      "version": "github:bitpay/node-buffers#04f4c4264e0d105db2b99b786843ed64f23230d8"
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -533,11 +547,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
       "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
-    },
-    "cached-constructors-x": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cached-constructors-x/-/cached-constructors-x-1.0.2.tgz",
-      "integrity": "sha512-7lKwmwXweW6E/31RHAJemLtZPfb2xvcABXknFF4b/dNYv4DbSGTgQHckXLQkNw6BB4HKFYW6mJgsNjADAy1ehw=="
     },
     "callsite": {
       "version": "1.0.0",
@@ -562,13 +571,6 @@
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
       }
     },
     "cli": {
@@ -786,14 +788,7 @@
         "cipher-base": "1.0.4",
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
-        "sha.js": "2.4.10"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
+        "sha.js": "2.4.11"
       }
     },
     "create-hmac": {
@@ -807,15 +802,7 @@
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
-        "sha.js": "2.4.10"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
-        }
+        "sha.js": "2.4.11"
       }
     },
     "cryptiles": {
@@ -836,7 +823,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.39"
+        "es5-ext": "0.10.41"
       }
     },
     "dashdash": {
@@ -949,11 +936,6 @@
         "readable-stream": "1.1.14"
       },
       "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -998,13 +980,6 @@
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.0",
         "minimalistic-crypto-utils": "1.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
       }
     },
     "enabled": {
@@ -1184,12 +1159,13 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.39",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.39.tgz",
-      "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
+      "version": "0.10.41",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.41.tgz",
+      "integrity": "sha512-MYK02wXfwTMie5TEJWPolgOsXEmz7wKCQaGzgmRjZOoV6VLG8I5dSv2bn6AOClXhK64gnSQTQ9W9MKvx87J4gw==",
       "requires": {
         "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       }
     },
     "es6-iterator": {
@@ -1198,7 +1174,7 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39",
+        "es5-ext": "0.10.41",
         "es6-symbol": "3.1.1"
       }
     },
@@ -1213,7 +1189,7 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39"
+        "es5-ext": "0.10.41"
       }
     },
     "escape-html": {
@@ -1682,29 +1658,6 @@
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
       "optional": true
     },
-    "has-own-property-x": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz",
-      "integrity": "sha512-HtRQTYpRFz/YVaQ7jh2mU5iorMAxFcML9FNOLMI1f8VNJ2K0hpOlXoi1a+nmVl6oUcGnhd6zYOFAVe7NUFStyQ==",
-      "requires": {
-        "cached-constructors-x": "1.0.2",
-        "to-object-x": "1.5.0",
-        "to-property-key-x": "2.0.2"
-      }
-    },
-    "has-symbol-support-x": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
-    },
-    "has-to-string-tag-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
-      "requires": {
-        "has-symbol-support-x": "1.4.2"
-      }
-    },
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -1716,13 +1669,6 @@
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "requires": {
         "inherits": "2.0.3"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
       }
     },
     "hash.js": {
@@ -1732,13 +1678,6 @@
       "requires": {
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.0"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
       }
     },
     "hasha": {
@@ -1808,7 +1747,7 @@
       "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-2.1.3.tgz",
       "integrity": "sha512-fUuDOrB47PqNK/BAMOS13v41UoaqIxqSLHX6CAbOD7OfT+/GCWO1/vPLfTNutOeXrv1ikuaZ3yux+33Z9vh+rw==",
       "requires": {
-        "buffer-from": "0.1.1",
+        "buffer-from": "0.1.2",
         "duplexer2": "0.0.2",
         "through2": "0.6.5"
       }
@@ -1822,11 +1761,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
-    },
-    "infinity-x": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/infinity-x/-/infinity-x-1.0.2.tgz",
-      "integrity": "sha512-2Ioz+exrAwlHxFBaDHQIbvUyjKFt0YjIal34/agfzx738aT1zBQwSU5A8Zgb1IQ2r24BtXrkeZZusxE40MyZaQ=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -1863,18 +1797,6 @@
         "sprintf": "0.1.5"
       }
     },
-    "is-array-buffer-x": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/is-array-buffer-x/-/is-array-buffer-x-1.7.0.tgz",
-      "integrity": "sha512-ufSZRMY2WZX5xyNvk0NOZAG7cgi35B/sGQDGqv8w0X7MoQ2GC9vedanJhuYTPaC4PUCqLQsda1w7NF+dPZmAJw==",
-      "requires": {
-        "attempt-x": "1.1.3",
-        "has-to-string-tag-x": "1.4.1",
-        "is-object-like-x": "1.7.1",
-        "object-get-own-property-descriptor-x": "3.2.0",
-        "to-string-tag-x": "1.4.3"
-      }
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -1890,28 +1812,6 @@
         "builtin-modules": "1.1.1"
       }
     },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
-    },
-    "is-falsey-x": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-falsey-x/-/is-falsey-x-1.0.3.tgz",
-      "integrity": "sha512-RWjusR6LXAhGa0Vus7aD1rwJuJwdJsvG3daAVMDvOAgvGuGm4eilNgoSuXhpv2/2qpLDvioAKTNb3t3XYidCNg==",
-      "requires": {
-        "to-boolean-x": "1.0.3"
-      }
-    },
-    "is-finite-x": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.4.tgz",
-      "integrity": "sha512-wdSI5zk/Pl21HzGcLWFoFzuDa8gsgcqhwZGAZryL2eU7RKf7+g+q4jL2gGItrBs/YtspkjOrJ4JxXNZqquoAWA==",
-      "requires": {
-        "infinity-x": "1.0.2",
-        "is-nan-x": "1.0.3"
-      }
-    },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -1920,82 +1820,10 @@
         "number-is-nan": "1.0.1"
       }
     },
-    "is-function-x": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz",
-      "integrity": "sha512-SreSSU1dlgYaXR5c0mm4qJHKYHIiGiEY+7Cd8/aRLLoMP/VvofD2XcWgBnP833ajpU5XzXbUSpfysnfKZLJFlg==",
-      "requires": {
-        "attempt-x": "1.1.3",
-        "has-to-string-tag-x": "1.4.1",
-        "is-falsey-x": "1.0.3",
-        "is-primitive": "2.0.0",
-        "normalize-space-x": "3.0.0",
-        "replace-comments-x": "2.0.0",
-        "to-boolean-x": "1.0.3",
-        "to-string-tag-x": "1.4.3"
-      },
-      "dependencies": {
-        "is-primitive": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-        }
-      }
-    },
-    "is-index-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz",
-      "integrity": "sha512-qULKLMepQLGC8rSVdi8uF2vI4LiDrU9XSDg1D+Aa657GIB7GV1jHpga7uXgQvkt/cpQ5mVBHUFTpSehYSqT6+A==",
-      "requires": {
-        "math-clamp-x": "1.2.0",
-        "max-safe-integer": "1.0.1",
-        "to-integer-x": "3.0.0",
-        "to-number-x": "2.0.0",
-        "to-string-symbols-supported-x": "1.0.2"
-      }
-    },
-    "is-nan-x": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-nan-x/-/is-nan-x-1.0.3.tgz",
-      "integrity": "sha512-WenNBLVGSZID8shogsB++42vF7gvotCfneXM9KMCAKwNPXa8VfAu/RWwpqvnK7dLOP4Z7uitocb0TZ6rAiOccA=="
-    },
-    "is-nil-x": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.2.tgz",
-      "integrity": "sha512-9aDY7ir7IGb5HlgqL+b38v2YMxf8S7MEHHxjHGzUhijg2crq47RKdxL37bS6dU0VN87wy2IBZP4akgQtIXmyvg==",
-      "requires": {
-        "lodash.isnull": "3.0.0",
-        "validate.io-undefined": "1.0.3"
-      }
-    },
-    "is-object-like-x": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.7.1.tgz",
-      "integrity": "sha512-89nz+kESAW2Y7udq+PdRX/dZnRN2WP1b19Gdv4OYE1Xjoekn1xf31l0ZPzT40qdPD7I2nveNFm9rxxI0vmnGHA==",
-      "requires": {
-        "is-function-x": "3.3.0",
-        "is-primitive": "3.0.0"
-      }
-    },
-    "is-primitive": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-3.0.0.tgz",
-      "integrity": "sha512-Qch+MMfMdu7DMY6XElM7LUJKPmkbXdTqNhqyehVflzis2a8Zd9V6U8qZybb32uUSmlO/dNmg3fsA5t0Q9TC0mA=="
-    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "is-string": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ="
-    },
-    "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -2065,7 +1893,7 @@
       "resolved": "https://registry.npmjs.org/jsonist/-/jsonist-2.1.0.tgz",
       "integrity": "sha1-RHek0WzTd/rsWNjPhwt+OS9tf+k=",
       "requires": {
-        "bl": "1.2.1",
+        "bl": "1.2.2",
         "hyperquest": "2.1.3",
         "json-stringify-safe": "5.0.1",
         "xtend": "4.0.1"
@@ -2095,9 +1923,9 @@
       }
     },
     "kareem": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.0.3.tgz",
-      "integrity": "sha512-WloXk3nyByx9FEB5WY7WFEXIZB/QA+zy7c2kJMjnZCebjepEyQcJzazgLiKcTS/ltZeEoeEQ1A1pau1fEDlnIA=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.0.5.tgz",
+      "integrity": "sha512-dfvpj3mCGJLZuADInhYrKaXkGarJxDqnTEiF91wK6fqwdCRmN+O4aEp8575UjZlQzDkzLI1WDL1uU7vyupURqw=="
     },
     "kew": {
       "version": "0.7.0",
@@ -2172,9 +2000,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "lodash.cond": {
       "version": "4.5.2",
@@ -2186,11 +2014,6 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
-    "lodash.isnull": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isnull/-/lodash.isnull-3.0.0.tgz",
-      "integrity": "sha1-+vvlnqHcon7teGU0A53YTC4HxW4="
     },
     "lodash.pad": {
       "version": "4.5.1",
@@ -2223,28 +2046,6 @@
         }
       }
     },
-    "math-clamp-x": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
-      "integrity": "sha512-tqpjpBcIf9UulApz3EjWXqTZpMlr2vLN9PryC9ghoyCuRmqZaf3JJhPddzgQpJnKLi2QhoFnvKBFtJekAIBSYg==",
-      "requires": {
-        "to-number-x": "2.0.0"
-      }
-    },
-    "math-sign-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz",
-      "integrity": "sha512-OzPas41Pn4d16KHnaXmGxxY3/l3zK4OIXtmIwdhgZsxz4FDDcNnbrABYPg2vGfxIkaT9ezGnzDviRH7RfF44jQ==",
-      "requires": {
-        "is-nan-x": "1.0.3",
-        "to-number-x": "2.0.0"
-      }
-    },
-    "max-safe-integer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/max-safe-integer/-/max-safe-integer-1.0.1.tgz",
-      "integrity": "sha1-84BgvixWPYwC5tSK85Ei/YO29BA="
-    },
     "md5.js": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
@@ -2264,11 +2065,6 @@
             "inherits": "2.0.3",
             "safe-buffer": "5.1.1"
           }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
     },
@@ -2343,32 +2139,32 @@
       }
     },
     "mongodb": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.0.2.tgz",
-      "integrity": "sha512-E50FmpSQchZAimn2uPIegoNoH9UQYR1yiGHtQPmmg8/Ekc97w6owHoqaBoz+assnd9V5LxMzmQ/VEWMsQMgZhQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.0.4.tgz",
+      "integrity": "sha512-90YIIs7A4ko4kCGafxxXj3foexCAlJBC0YLwwIKgSLoE7Vni2IqUMz6HSsZ3zbXOfR1KWtxfnc0RyAMAY/ViLg==",
       "requires": {
-        "mongodb-core": "3.0.2"
+        "mongodb-core": "3.0.4"
       }
     },
     "mongodb-core": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.0.2.tgz",
-      "integrity": "sha512-p1B0qwFQUw6C1OlFJnrOJp8KaX7MuGoogRbTaupRt0y+pPRkMllHWtE9V6i1CDtTvI3/3sy2sQwqWez7zuXEAA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.0.4.tgz",
+      "integrity": "sha512-OTH267FjfwBdEufSnrgd+u8HuLWRuQ6p8DR0XirPl2BdlLEMh4XwjJf1RTlruILp5p2m1w8dDC8rCxibC3W8qQ==",
       "requires": {
-        "bson": "1.0.4",
+        "bson": "1.0.6",
         "require_optional": "1.0.1"
       }
     },
     "mongoose": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.0.3.tgz",
-      "integrity": "sha512-y4NlLzZaQe5vJHjcEjHLKK6utjs7sVEPN971+d1vVJJGrmA+zeeFA1MEmC1J0ujD34eOSghnExXJPwCrxHHZCw==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.0.11.tgz",
+      "integrity": "sha512-VAnMQ356GdQauWJM4KjQh5VuysPv8r+Nm7bKk9F/np3VQwe31B/p6ynQQVmLsTwmkjF5Dqw1pC8Rlg8CCa3rNA==",
       "requires": {
         "async": "2.1.4",
-        "bson": "1.0.4",
-        "kareem": "2.0.3",
+        "bson": "1.0.6",
+        "kareem": "2.0.5",
         "lodash.get": "4.4.2",
-        "mongodb": "3.0.2",
+        "mongodb": "3.0.4",
         "mongoose-legacy-pluralize": "1.0.2",
         "mpath": "0.3.0",
         "mquery": "3.0.0",
@@ -2382,13 +2178,8 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
           "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "4.17.5"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -2421,11 +2212,6 @@
             "ms": "2.0.0"
           }
         },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
         "sliced": {
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
@@ -2444,11 +2230,6 @@
       "integrity": "sha1-1bAWkSUzJql6K77p5hxV2NYDUeI=",
       "optional": true
     },
-    "nan-x": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nan-x/-/nan-x-1.0.2.tgz",
-      "integrity": "sha512-dndRmy03JQEN+Nh6WjQl7/OstIozeEmrtWe4TE7mEqJ8W8oMD8m2tHjsLPWt//e3hLAeRSbs4pxMyc5pk/nCkQ=="
-    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -2458,6 +2239,11 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/network-byte-order/-/network-byte-order-0.2.0.tgz",
       "integrity": "sha1-asEb9Ev2ENrt2+kKCaXIF8bg0rM="
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "node-abi": {
       "version": "2.3.0",
@@ -2543,16 +2329,6 @@
         "validate-npm-package-license": "3.0.1"
       }
     },
-    "normalize-space-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-3.0.0.tgz",
-      "integrity": "sha512-tbCJerqZCCHPst4rRKgsTanLf45fjOyeAU5zE3mhDxJtFJKt66q39g2XArWhXelgTFVib8mNBUm6Wrd0LxYcfQ==",
-      "requires": {
-        "cached-constructors-x": "1.0.2",
-        "trim-x": "3.0.0",
-        "white-space-x": "3.0.1"
-      }
-    },
     "npmlog": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
@@ -2584,30 +2360,6 @@
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "optional": true
-    },
-    "object-get-own-property-descriptor-x": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/object-get-own-property-descriptor-x/-/object-get-own-property-descriptor-x-3.2.0.tgz",
-      "integrity": "sha512-Z/0fIrptD9YuzN+SNK/1kxAEaBcPQM4gSrtOSMSi9eplnL/AbyQcAyAlreAoAzmBon+DQ1Z+AdhxyQSvav5Fyg==",
-      "requires": {
-        "attempt-x": "1.1.3",
-        "has-own-property-x": "3.2.0",
-        "has-symbol-support-x": "1.4.2",
-        "is-falsey-x": "1.0.3",
-        "is-index-x": "1.1.0",
-        "is-primitive": "2.0.0",
-        "is-string": "1.0.4",
-        "property-is-enumerable-x": "1.1.0",
-        "to-object-x": "1.5.0",
-        "to-property-key-x": "2.0.2"
-      },
-      "dependencies": {
-        "is-primitive": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-        }
-      }
     },
     "on-finished": {
       "version": "2.3.0",
@@ -2677,17 +2429,6 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
-    },
-    "parse-int-x": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz",
-      "integrity": "sha512-NIMm52gmd1+0qxJK8lV3OZ4zzWpRH1xcz9xCHXl+DNzddwUdS4NEtd7BmTeK7iCIXoaK5e6BoDMHgieH2eNIhg==",
-      "requires": {
-        "cached-constructors-x": "1.0.2",
-        "nan-x": "1.0.2",
-        "to-string-x": "1.4.5",
-        "trim-left-x": "3.0.0"
-      }
     },
     "parse-json": {
       "version": "2.2.0",
@@ -2852,7 +2593,7 @@
         "npmlog": "2.0.4",
         "os-homedir": "1.0.2",
         "pump": "1.0.3",
-        "rc": "1.2.5",
+        "rc": "1.2.6",
         "simple-get": "1.4.3",
         "tar-fs": "1.16.0",
         "tar-stream": "1.5.5",
@@ -2889,7 +2630,7 @@
         "npmlog": "4.1.2",
         "os-homedir": "1.0.2",
         "pump": "2.0.1",
-        "rc": "1.2.5",
+        "rc": "1.2.6",
         "simple-get": "2.7.0",
         "tar-fs": "1.16.0",
         "tunnel-agent": "0.6.0",
@@ -2963,15 +2704,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
     },
-    "property-is-enumerable-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/property-is-enumerable-x/-/property-is-enumerable-x-1.1.0.tgz",
-      "integrity": "sha512-22cKy3w3OpRswU6to9iKWDDlg+F9vF2REcwGlGW23jyLjHb1U/jJEWA44sWupOnkhGfDgotU6Lw+N2oyhNi+5A==",
-      "requires": {
-        "to-object-x": "1.5.0",
-        "to-property-key-x": "2.0.2"
-      }
-    },
     "proxy-addr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
@@ -3016,9 +2748,9 @@
       }
     },
     "rc": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
-      "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
+      "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
       "optional": true,
       "requires": {
         "deep-extend": "0.4.2",
@@ -3092,15 +2824,6 @@
       "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
       "integrity": "sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk="
     },
-    "replace-comments-x": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-2.0.0.tgz",
-      "integrity": "sha512-+vMP4jqU+8HboLWms6YMNEiaZG5hh1oR6ENCnGYDF/UQ7aYiJUK/8tcl3+KZAHRCKKa3gqzrfiarlUBHQSgRlg==",
-      "requires": {
-        "require-coercible-to-string-x": "1.0.2",
-        "to-string-x": "1.4.5"
-      }
-    },
     "request": {
       "version": "2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
@@ -3168,23 +2891,6 @@
         "throttleit": "1.0.0"
       }
     },
-    "require-coercible-to-string-x": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/require-coercible-to-string-x/-/require-coercible-to-string-x-1.0.2.tgz",
-      "integrity": "sha512-GZ3BSCL0n/zhho8ITganW9FGPh0Kxhq71nCjck8Qau/30Wf4Po8a3XpQdzEMFiXCwZ/0m0E3lKSdSG8gkcIofQ==",
-      "requires": {
-        "require-object-coercible-x": "1.4.3",
-        "to-string-x": "1.4.5"
-      }
-    },
-    "require-object-coercible-x": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/require-object-coercible-x/-/require-object-coercible-x-1.4.3.tgz",
-      "integrity": "sha512-5wEaS+NIiU5HLJQTqBQ+6XHtX7yplUS374j/H/nRDlc7rMWfENqp026jnUHWAOCZ+ekixkXuFHEnTF28oqqVLA==",
-      "requires": {
-        "is-nil-x": "1.4.2"
-      }
-    },
     "require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
@@ -3223,13 +2929,6 @@
       "requires": {
         "hash-base": "2.0.2",
         "inherits": "2.0.3"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
       }
     },
     "safe-buffer": {
@@ -3311,19 +3010,12 @@
       "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
     },
     "sha.js": {
-      "version": "2.4.10",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
-      "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
       }
     },
     "signal-exit": {
@@ -3695,7 +3387,7 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "requires": {
-        "bl": "1.2.1",
+        "bl": "1.2.2",
         "end-of-stream": "1.4.1",
         "readable-stream": "2.0.6",
         "xtend": "4.0.1"
@@ -3720,11 +3412,6 @@
         "xtend": "4.0.1"
       },
       "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -3749,138 +3436,12 @@
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
       "optional": true
     },
-    "to-boolean-x": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.3.tgz",
-      "integrity": "sha512-kQiMyJUgFprL8J+0CfgJuaSFKJMs3EvFe27/6aj/hVzVZT0HY4aA1QjPldLNxzBmjhLcapp7CctYHuD8QqtS3g=="
-    },
-    "to-integer-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz",
-      "integrity": "sha512-794L2Lpwjtynm7RxahJi2YdbRY75gTxUW27TMuN26UgwPkmJb/+HPhkFEFbz+E4vNoiP0dxq5tq5fkXoXLaK/w==",
-      "requires": {
-        "is-finite-x": "3.0.4",
-        "is-nan-x": "1.0.3",
-        "math-sign-x": "3.0.0",
-        "to-number-x": "2.0.0"
-      }
-    },
-    "to-number-x": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz",
-      "integrity": "sha512-lGOnCoccUoSzjZ/9Uen8TC4+VFaQcFGhTroWTv2tYWxXgyJV1zqAZ8hEIMkez/Eo790fBMOjidTnQ/OJSCvAoQ==",
-      "requires": {
-        "cached-constructors-x": "1.0.2",
-        "nan-x": "1.0.2",
-        "parse-int-x": "2.0.0",
-        "to-primitive-x": "1.1.0",
-        "trim-x": "3.0.0"
-      }
-    },
-    "to-object-x": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/to-object-x/-/to-object-x-1.5.0.tgz",
-      "integrity": "sha512-AKn5GQcdWky+s20vjWkt+Wa6y3dxQH3yQyMBhOfBOPldUwqwhgvlqcIg5H092ntNc+TX8/Cxzs1kMHH19pyCnA==",
-      "requires": {
-        "cached-constructors-x": "1.0.2",
-        "require-object-coercible-x": "1.4.3"
-      }
-    },
-    "to-primitive-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/to-primitive-x/-/to-primitive-x-1.1.0.tgz",
-      "integrity": "sha512-gyMY0gi3wjK3e4MUBKqv9Zl8QGcWguIkaUr2VJmoBEsOpDcpDZSEyljR773eVG4maS48uX7muLkoQoh/BA82OQ==",
-      "requires": {
-        "has-symbol-support-x": "1.4.2",
-        "is-date-object": "1.0.1",
-        "is-function-x": "3.3.0",
-        "is-nil-x": "1.4.2",
-        "is-primitive": "2.0.0",
-        "is-symbol": "1.0.1",
-        "require-object-coercible-x": "1.4.3",
-        "validate.io-undefined": "1.0.3"
-      },
-      "dependencies": {
-        "is-primitive": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-        }
-      }
-    },
-    "to-property-key-x": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/to-property-key-x/-/to-property-key-x-2.0.2.tgz",
-      "integrity": "sha512-YISLpZFYIazNm0P8hLsKEEUEZ3m8U3+eDysJZqTu3+B9tQp+2TrMpaEGT8Agh4fZ5LSoums60/glNEzk5ozqrg==",
-      "requires": {
-        "has-symbol-support-x": "1.4.2",
-        "to-primitive-x": "1.1.0",
-        "to-string-x": "1.4.5"
-      }
-    },
-    "to-string-symbols-supported-x": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/to-string-symbols-supported-x/-/to-string-symbols-supported-x-1.0.2.tgz",
-      "integrity": "sha512-3MRqhIhSNVDsVAk4M6WNcuBZrAQe54W13xrXX6RzxXS+pA4nj6DQ96RegQS5z9BSNyYbFsBsPvMVDIpP+a/5RA==",
-      "requires": {
-        "cached-constructors-x": "1.0.2",
-        "has-symbol-support-x": "1.4.2",
-        "is-symbol": "1.0.1"
-      }
-    },
-    "to-string-tag-x": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.4.3.tgz",
-      "integrity": "sha512-5+0EZ6dOVt/XArXmkooxPzWxmOR081HM/uXitUow7h11WYg5pPo15uYqDWuqO7ZY+O3Atn/dG26wcJCK+mFevg==",
-      "requires": {
-        "lodash.isnull": "3.0.0",
-        "validate.io-undefined": "1.0.3"
-      }
-    },
-    "to-string-x": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/to-string-x/-/to-string-x-1.4.5.tgz",
-      "integrity": "sha512-5xzlZDyDa9BUWNjNzZzHgKQ95PnV7qjvEhbqpFaj1ixaHgfJXOFaa3xdMJ+WLYd4hhaMJaxt8Pt5uKaWXfruXA==",
-      "requires": {
-        "cached-constructors-x": "1.0.2",
-        "is-symbol": "1.0.1"
-      }
-    },
     "tough-cookie": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
       "requires": {
         "punycode": "1.4.1"
-      }
-    },
-    "trim-left-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-3.0.0.tgz",
-      "integrity": "sha512-+m6cqkppI+CxQBTwWEZliOHpOBnCArGyMnS1WCLb6IRgukhTkiQu/TNEN5Lj2eM9jk8ewJsc7WxFZfmwNpRXWQ==",
-      "requires": {
-        "cached-constructors-x": "1.0.2",
-        "require-coercible-to-string-x": "1.0.2",
-        "white-space-x": "3.0.1"
-      }
-    },
-    "trim-right-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-3.0.0.tgz",
-      "integrity": "sha512-iIqEsWEbWVodqdixJHi4FoayJkUxhoL4AvSNGp4FF4FfQKRPGizt8++/RnyC9od75y7P/S6EfONoVqP+NddiKA==",
-      "requires": {
-        "cached-constructors-x": "1.0.2",
-        "require-coercible-to-string-x": "1.0.2",
-        "white-space-x": "3.0.1"
-      }
-    },
-    "trim-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-3.0.0.tgz",
-      "integrity": "sha512-w8s38RAUScQ6t3XqMkS75iz5ZkIYLQpVnv2lp3IuTS36JdlVzC54oe6okOf4Wz3UH4rr3XAb2xR3kR5Xei82fw==",
-      "requires": {
-        "trim-left-x": "3.0.0",
-        "trim-right-x": "3.0.0"
       }
     },
     "triple-beam": {
@@ -3986,11 +3547,6 @@
         "spdx-expression-parse": "1.0.4"
       }
     },
-    "validate.io-undefined": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/validate.io-undefined/-/validate.io-undefined-1.0.3.tgz",
-      "integrity": "sha1-fif8uzFbhB54JDQxiXZxkp4gt/Q="
-    },
     "vary": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
@@ -4031,11 +3587,6 @@
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "optional": true
-    },
-    "white-space-x": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-3.0.1.tgz",
-      "integrity": "sha512-BwMFXQNPna/4RsNPOgldVYn+FkEv+lc3wUiFzuaW6Z2DH/oSk1UrRD6SBqDgWQO4JU+aBq3PVuPD9Vz0j7mh0w=="
     },
     "wide-align": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/formatio": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
     "JSONStream": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
@@ -133,11 +142,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
-    "attempt-x": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/attempt-x/-/attempt-x-1.1.3.tgz",
-      "integrity": "sha512-y/+ek8IjxVpTbj/phC87jK5YRhlP5Uu7FlQdCmYuut1DTjNruyrGqUWi5bcX1VKsQX1B0FX16A1hqHomKpHv3A=="
-    },
     "aws-sign2": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
@@ -199,7 +203,7 @@
         },
         "elliptic": {
           "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.2.tgz",
+          "resolved": "http://registry.npmjs.org/elliptic/-/elliptic-6.3.2.tgz",
           "integrity": "sha1-5MgeCCnPCmWrcOmYuCMnI7XBvEg=",
           "requires": {
             "bn.js": "4.11.6",
@@ -207,11 +211,6 @@
             "hash.js": "1.1.3",
             "inherits": "2.0.3"
           }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
     },
@@ -337,12 +336,9 @@
           "resolved": "https://registry.npmjs.org/buffer-compare/-/buffer-compare-1.0.0.tgz",
           "integrity": "sha1-rKp6lm6Y7un64Usxw5pfFY+zxKI="
         },
-        "buffers": {
-          "version": "github:bitpay/node-buffers#04f4c4264e0d105db2b99b786843ed64f23230d8"
-        },
         "elliptic": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
+          "resolved": "http://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
           "integrity": "sha1-hlybQgv75VAGuflp+XoNLESWZZU=",
           "requires": {
             "bn.js": "2.0.4",
@@ -370,19 +366,44 @@
         "bloom-filter": "0.2.0",
         "buffers": "github:bitpay/node-buffers#04f4c4264e0d105db2b99b786843ed64f23230d8",
         "socks5-client": "0.3.6"
-      },
-      "dependencies": {
-        "buffers": {
-          "version": "github:bitpay/node-buffers#04f4c4264e0d105db2b99b786843ed64f23230d8"
-        }
       }
     },
     "bl": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
-        "readable-stream": "2.0.6"
+        "readable-stream": "2.3.5",
+        "safe-buffer": "5.1.1"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "readable-stream": {
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
       }
     },
     "blob": {
@@ -469,6 +490,12 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
     "browserify-aes": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
@@ -481,14 +508,6 @@
         "evp_bytestokey": "1.0.3",
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
-        }
       }
     },
     "bs58": {
@@ -510,18 +529,18 @@
       "integrity": "sha1-W+e+hTr4kZjR9N3AkNHWakiu9ZY="
     },
     "buffer-from": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.1.tgz",
-      "integrity": "sha1-V7GLHaChnsBvM4N6UnWiQjUb114=",
-      "requires": {
-        "is-array-buffer-x": "1.7.0"
-      }
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+      "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
     },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "optional": true
+    },
+    "buffers": {
+      "version": "github:bitpay/node-buffers#04f4c4264e0d105db2b99b786843ed64f23230d8"
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -533,11 +552,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
       "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
-    },
-    "cached-constructors-x": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cached-constructors-x/-/cached-constructors-x-1.0.2.tgz",
-      "integrity": "sha512-7lKwmwXweW6E/31RHAJemLtZPfb2xvcABXknFF4b/dNYv4DbSGTgQHckXLQkNw6BB4HKFYW6mJgsNjADAy1ehw=="
     },
     "callsite": {
       "version": "1.0.0",
@@ -562,13 +576,6 @@
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
       }
     },
     "cli": {
@@ -681,6 +688,12 @@
         "delayed-stream": "1.0.0"
       }
     },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
     "component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
@@ -688,9 +701,10 @@
       "optional": true
     },
     "component-emitter": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-      "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
     },
     "component-inherit": {
       "version": "0.0.3",
@@ -773,6 +787,12 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "cookiejar": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
+      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -786,14 +806,7 @@
         "cipher-base": "1.0.4",
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
-        "sha.js": "2.4.10"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
+        "sha.js": "2.4.11"
       }
     },
     "create-hmac": {
@@ -807,15 +820,7 @@
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
-        "sha.js": "2.4.10"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
-        }
+        "sha.js": "2.4.11"
       }
     },
     "cryptiles": {
@@ -836,7 +841,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.39"
+        "es5-ext": "0.10.41"
       }
     },
     "dashdash": {
@@ -920,6 +925,12 @@
         "kuler": "0.0.0"
       }
     },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
     "doctrine": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
@@ -949,11 +960,6 @@
         "readable-stream": "1.1.14"
       },
       "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -998,13 +1004,6 @@
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.0",
         "minimalistic-crypto-utils": "1.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
       }
     },
     "enabled": {
@@ -1109,6 +1108,12 @@
         "yeast": "0.1.2"
       },
       "dependencies": {
+        "component-emitter": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
+          "optional": true
+        },
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
@@ -1184,12 +1189,13 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.39",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.39.tgz",
-      "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
+      "version": "0.10.41",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.41.tgz",
+      "integrity": "sha512-MYK02wXfwTMie5TEJWPolgOsXEmz7wKCQaGzgmRjZOoV6VLG8I5dSv2bn6AOClXhK64gnSQTQ9W9MKvx87J4gw==",
       "requires": {
         "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       }
     },
     "es6-iterator": {
@@ -1198,7 +1204,7 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39",
+        "es5-ext": "0.10.41",
         "es6-symbol": "3.1.1"
       }
     },
@@ -1213,13 +1219,19 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39"
+        "es5-ext": "0.10.41"
       }
     },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "eslint-config-airbnb-base": {
       "version": "12.1.0",
@@ -1499,6 +1511,12 @@
         }
       }
     },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
+      "dev": true
+    },
     "forwarded": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
@@ -1638,6 +1656,12 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
     "har-schema": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
@@ -1682,28 +1706,11 @@
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
       "optional": true
     },
-    "has-own-property-x": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz",
-      "integrity": "sha512-HtRQTYpRFz/YVaQ7jh2mU5iorMAxFcML9FNOLMI1f8VNJ2K0hpOlXoi1a+nmVl6oUcGnhd6zYOFAVe7NUFStyQ==",
-      "requires": {
-        "cached-constructors-x": "1.0.2",
-        "to-object-x": "1.5.0",
-        "to-property-key-x": "2.0.2"
-      }
-    },
-    "has-symbol-support-x": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
-    },
-    "has-to-string-tag-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
-      "requires": {
-        "has-symbol-support-x": "1.4.2"
-      }
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -1716,13 +1723,6 @@
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "requires": {
         "inherits": "2.0.3"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
       }
     },
     "hash.js": {
@@ -1732,13 +1732,6 @@
       "requires": {
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.0"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
       }
     },
     "hasha": {
@@ -1760,6 +1753,12 @@
         "hoek": "2.16.3",
         "sntp": "1.0.9"
       }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -1808,7 +1807,7 @@
       "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-2.1.3.tgz",
       "integrity": "sha512-fUuDOrB47PqNK/BAMOS13v41UoaqIxqSLHX6CAbOD7OfT+/GCWO1/vPLfTNutOeXrv1ikuaZ3yux+33Z9vh+rw==",
       "requires": {
-        "buffer-from": "0.1.1",
+        "buffer-from": "0.1.2",
         "duplexer2": "0.0.2",
         "through2": "0.6.5"
       }
@@ -1822,11 +1821,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
-    },
-    "infinity-x": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/infinity-x/-/infinity-x-1.0.2.tgz",
-      "integrity": "sha512-2Ioz+exrAwlHxFBaDHQIbvUyjKFt0YjIal34/agfzx738aT1zBQwSU5A8Zgb1IQ2r24BtXrkeZZusxE40MyZaQ=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -1863,18 +1857,6 @@
         "sprintf": "0.1.5"
       }
     },
-    "is-array-buffer-x": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/is-array-buffer-x/-/is-array-buffer-x-1.7.0.tgz",
-      "integrity": "sha512-ufSZRMY2WZX5xyNvk0NOZAG7cgi35B/sGQDGqv8w0X7MoQ2GC9vedanJhuYTPaC4PUCqLQsda1w7NF+dPZmAJw==",
-      "requires": {
-        "attempt-x": "1.1.3",
-        "has-to-string-tag-x": "1.4.1",
-        "is-object-like-x": "1.7.1",
-        "object-get-own-property-descriptor-x": "3.2.0",
-        "to-string-tag-x": "1.4.3"
-      }
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -1890,28 +1872,6 @@
         "builtin-modules": "1.1.1"
       }
     },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
-    },
-    "is-falsey-x": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-falsey-x/-/is-falsey-x-1.0.3.tgz",
-      "integrity": "sha512-RWjusR6LXAhGa0Vus7aD1rwJuJwdJsvG3daAVMDvOAgvGuGm4eilNgoSuXhpv2/2qpLDvioAKTNb3t3XYidCNg==",
-      "requires": {
-        "to-boolean-x": "1.0.3"
-      }
-    },
-    "is-finite-x": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.4.tgz",
-      "integrity": "sha512-wdSI5zk/Pl21HzGcLWFoFzuDa8gsgcqhwZGAZryL2eU7RKf7+g+q4jL2gGItrBs/YtspkjOrJ4JxXNZqquoAWA==",
-      "requires": {
-        "infinity-x": "1.0.2",
-        "is-nan-x": "1.0.3"
-      }
-    },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -1920,82 +1880,10 @@
         "number-is-nan": "1.0.1"
       }
     },
-    "is-function-x": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz",
-      "integrity": "sha512-SreSSU1dlgYaXR5c0mm4qJHKYHIiGiEY+7Cd8/aRLLoMP/VvofD2XcWgBnP833ajpU5XzXbUSpfysnfKZLJFlg==",
-      "requires": {
-        "attempt-x": "1.1.3",
-        "has-to-string-tag-x": "1.4.1",
-        "is-falsey-x": "1.0.3",
-        "is-primitive": "2.0.0",
-        "normalize-space-x": "3.0.0",
-        "replace-comments-x": "2.0.0",
-        "to-boolean-x": "1.0.3",
-        "to-string-tag-x": "1.4.3"
-      },
-      "dependencies": {
-        "is-primitive": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-        }
-      }
-    },
-    "is-index-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz",
-      "integrity": "sha512-qULKLMepQLGC8rSVdi8uF2vI4LiDrU9XSDg1D+Aa657GIB7GV1jHpga7uXgQvkt/cpQ5mVBHUFTpSehYSqT6+A==",
-      "requires": {
-        "math-clamp-x": "1.2.0",
-        "max-safe-integer": "1.0.1",
-        "to-integer-x": "3.0.0",
-        "to-number-x": "2.0.0",
-        "to-string-symbols-supported-x": "1.0.2"
-      }
-    },
-    "is-nan-x": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-nan-x/-/is-nan-x-1.0.3.tgz",
-      "integrity": "sha512-WenNBLVGSZID8shogsB++42vF7gvotCfneXM9KMCAKwNPXa8VfAu/RWwpqvnK7dLOP4Z7uitocb0TZ6rAiOccA=="
-    },
-    "is-nil-x": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.2.tgz",
-      "integrity": "sha512-9aDY7ir7IGb5HlgqL+b38v2YMxf8S7MEHHxjHGzUhijg2crq47RKdxL37bS6dU0VN87wy2IBZP4akgQtIXmyvg==",
-      "requires": {
-        "lodash.isnull": "3.0.0",
-        "validate.io-undefined": "1.0.3"
-      }
-    },
-    "is-object-like-x": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.7.1.tgz",
-      "integrity": "sha512-89nz+kESAW2Y7udq+PdRX/dZnRN2WP1b19Gdv4OYE1Xjoekn1xf31l0ZPzT40qdPD7I2nveNFm9rxxI0vmnGHA==",
-      "requires": {
-        "is-function-x": "3.3.0",
-        "is-primitive": "3.0.0"
-      }
-    },
-    "is-primitive": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-3.0.0.tgz",
-      "integrity": "sha512-Qch+MMfMdu7DMY6XElM7LUJKPmkbXdTqNhqyehVflzis2a8Zd9V6U8qZybb32uUSmlO/dNmg3fsA5t0Q9TC0mA=="
-    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "is-string": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ="
-    },
-    "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -2065,7 +1953,7 @@
       "resolved": "https://registry.npmjs.org/jsonist/-/jsonist-2.1.0.tgz",
       "integrity": "sha1-RHek0WzTd/rsWNjPhwt+OS9tf+k=",
       "requires": {
-        "bl": "1.2.1",
+        "bl": "1.2.2",
         "hyperquest": "2.1.3",
         "json-stringify-safe": "5.0.1",
         "xtend": "4.0.1"
@@ -2093,6 +1981,12 @@
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
+    },
+    "just-extend": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
     },
     "kareem": {
       "version": "2.0.3",
@@ -2187,11 +2081,6 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
-    "lodash.isnull": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isnull/-/lodash.isnull-3.0.0.tgz",
-      "integrity": "sha1-+vvlnqHcon7teGU0A53YTC4HxW4="
-    },
     "lodash.pad": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
@@ -2223,27 +2112,11 @@
         }
       }
     },
-    "math-clamp-x": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
-      "integrity": "sha512-tqpjpBcIf9UulApz3EjWXqTZpMlr2vLN9PryC9ghoyCuRmqZaf3JJhPddzgQpJnKLi2QhoFnvKBFtJekAIBSYg==",
-      "requires": {
-        "to-number-x": "2.0.0"
-      }
-    },
-    "math-sign-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz",
-      "integrity": "sha512-OzPas41Pn4d16KHnaXmGxxY3/l3zK4OIXtmIwdhgZsxz4FDDcNnbrABYPg2vGfxIkaT9ezGnzDviRH7RfF44jQ==",
-      "requires": {
-        "is-nan-x": "1.0.3",
-        "to-number-x": "2.0.0"
-      }
-    },
-    "max-safe-integer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/max-safe-integer/-/max-safe-integer-1.0.1.tgz",
-      "integrity": "sha1-84BgvixWPYwC5tSK85Ei/YO29BA="
+    "lolex": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
+      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.4",
@@ -2264,11 +2137,6 @@
             "inherits": "2.0.3",
             "safe-buffer": "5.1.1"
           }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
     },
@@ -2340,6 +2208,35 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.5.tgz",
+      "integrity": "sha512-3MM3UjZ5p8EJrYpG7s+29HAI9G7sTzKEe4+w37Dg0QP7qL4XGsV+Q2xet2cE37AqdgN1OtYQB6Vl98YiPV3PgA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "mongodb": {
@@ -2444,11 +2341,6 @@
       "integrity": "sha1-1bAWkSUzJql6K77p5hxV2NYDUeI=",
       "optional": true
     },
-    "nan-x": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nan-x/-/nan-x-1.0.2.tgz",
-      "integrity": "sha512-dndRmy03JQEN+Nh6WjQl7/OstIozeEmrtWe4TE7mEqJ8W8oMD8m2tHjsLPWt//e3hLAeRSbs4pxMyc5pk/nCkQ=="
-    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -2458,6 +2350,41 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/network-byte-order/-/network-byte-order-0.2.0.tgz",
       "integrity": "sha1-asEb9Ev2ENrt2+kKCaXIF8bg0rM="
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "nise": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.2.tgz",
+      "integrity": "sha512-KPKb+wvETBiwb4eTwtR/OsA2+iijXP+VnlSFYJo3EHjm2yjek1NWxHOUQat3i7xNLm1Bm18UA5j5Wor0yO2GtA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "2.0.0",
+        "just-extend": "1.1.27",
+        "lolex": "2.3.2",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-abi": {
       "version": "2.3.0",
@@ -2543,16 +2470,6 @@
         "validate-npm-package-license": "3.0.1"
       }
     },
-    "normalize-space-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-3.0.0.tgz",
-      "integrity": "sha512-tbCJerqZCCHPst4rRKgsTanLf45fjOyeAU5zE3mhDxJtFJKt66q39g2XArWhXelgTFVib8mNBUm6Wrd0LxYcfQ==",
-      "requires": {
-        "cached-constructors-x": "1.0.2",
-        "trim-x": "3.0.0",
-        "white-space-x": "3.0.1"
-      }
-    },
     "npmlog": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
@@ -2584,30 +2501,6 @@
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "optional": true
-    },
-    "object-get-own-property-descriptor-x": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/object-get-own-property-descriptor-x/-/object-get-own-property-descriptor-x-3.2.0.tgz",
-      "integrity": "sha512-Z/0fIrptD9YuzN+SNK/1kxAEaBcPQM4gSrtOSMSi9eplnL/AbyQcAyAlreAoAzmBon+DQ1Z+AdhxyQSvav5Fyg==",
-      "requires": {
-        "attempt-x": "1.1.3",
-        "has-own-property-x": "3.2.0",
-        "has-symbol-support-x": "1.4.2",
-        "is-falsey-x": "1.0.3",
-        "is-index-x": "1.1.0",
-        "is-primitive": "2.0.0",
-        "is-string": "1.0.4",
-        "property-is-enumerable-x": "1.1.0",
-        "to-object-x": "1.5.0",
-        "to-property-key-x": "2.0.2"
-      },
-      "dependencies": {
-        "is-primitive": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-        }
-      }
     },
     "on-finished": {
       "version": "2.3.0",
@@ -2677,17 +2570,6 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
-    },
-    "parse-int-x": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz",
-      "integrity": "sha512-NIMm52gmd1+0qxJK8lV3OZ4zzWpRH1xcz9xCHXl+DNzddwUdS4NEtd7BmTeK7iCIXoaK5e6BoDMHgieH2eNIhg==",
-      "requires": {
-        "cached-constructors-x": "1.0.2",
-        "nan-x": "1.0.2",
-        "to-string-x": "1.4.5",
-        "trim-left-x": "3.0.0"
-      }
     },
     "parse-json": {
       "version": "2.2.0",
@@ -2852,7 +2734,7 @@
         "npmlog": "2.0.4",
         "os-homedir": "1.0.2",
         "pump": "1.0.3",
-        "rc": "1.2.5",
+        "rc": "1.2.6",
         "simple-get": "1.4.3",
         "tar-fs": "1.16.0",
         "tar-stream": "1.5.5",
@@ -2889,7 +2771,7 @@
         "npmlog": "4.1.2",
         "os-homedir": "1.0.2",
         "pump": "2.0.1",
-        "rc": "1.2.5",
+        "rc": "1.2.6",
         "simple-get": "2.7.0",
         "tar-fs": "1.16.0",
         "tunnel-agent": "0.6.0",
@@ -2963,15 +2845,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
     },
-    "property-is-enumerable-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/property-is-enumerable-x/-/property-is-enumerable-x-1.1.0.tgz",
-      "integrity": "sha512-22cKy3w3OpRswU6to9iKWDDlg+F9vF2REcwGlGW23jyLjHb1U/jJEWA44sWupOnkhGfDgotU6Lw+N2oyhNi+5A==",
-      "requires": {
-        "to-object-x": "1.5.0",
-        "to-property-key-x": "2.0.2"
-      }
-    },
     "proxy-addr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
@@ -3016,9 +2889,9 @@
       }
     },
     "rc": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
-      "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
+      "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
       "optional": true,
       "requires": {
         "deep-extend": "0.4.2",
@@ -3092,15 +2965,6 @@
       "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
       "integrity": "sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk="
     },
-    "replace-comments-x": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-2.0.0.tgz",
-      "integrity": "sha512-+vMP4jqU+8HboLWms6YMNEiaZG5hh1oR6ENCnGYDF/UQ7aYiJUK/8tcl3+KZAHRCKKa3gqzrfiarlUBHQSgRlg==",
-      "requires": {
-        "require-coercible-to-string-x": "1.0.2",
-        "to-string-x": "1.4.5"
-      }
-    },
     "request": {
       "version": "2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
@@ -3168,23 +3032,6 @@
         "throttleit": "1.0.0"
       }
     },
-    "require-coercible-to-string-x": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/require-coercible-to-string-x/-/require-coercible-to-string-x-1.0.2.tgz",
-      "integrity": "sha512-GZ3BSCL0n/zhho8ITganW9FGPh0Kxhq71nCjck8Qau/30Wf4Po8a3XpQdzEMFiXCwZ/0m0E3lKSdSG8gkcIofQ==",
-      "requires": {
-        "require-object-coercible-x": "1.4.3",
-        "to-string-x": "1.4.5"
-      }
-    },
-    "require-object-coercible-x": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/require-object-coercible-x/-/require-object-coercible-x-1.4.3.tgz",
-      "integrity": "sha512-5wEaS+NIiU5HLJQTqBQ+6XHtX7yplUS374j/H/nRDlc7rMWfENqp026jnUHWAOCZ+ekixkXuFHEnTF28oqqVLA==",
-      "requires": {
-        "is-nil-x": "1.4.2"
-      }
-    },
     "require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
@@ -3223,19 +3070,18 @@
       "requires": {
         "hash-base": "2.0.2",
         "inherits": "2.0.3"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
       }
     },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "samsam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
     },
     "secp256k1": {
       "version": "3.2.5",
@@ -3311,19 +3157,12 @@
       "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
     },
     "sha.js": {
-      "version": "2.4.10",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
-      "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
       }
     },
     "signal-exit": {
@@ -3354,6 +3193,38 @@
       "resolved": "https://registry.npmjs.org/simple-mime/-/simple-mime-0.1.0.tgz",
       "integrity": "sha1-lfUXxPRm18/1YacfydqyWW6p7y4=",
       "optional": true
+    },
+    "sinon": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.8.tgz",
+      "integrity": "sha512-EWZf/D5BN/BbDFPmwY2abw6wgELVmk361self+lcwEmVw0WWUxURp2S/YoDB2WG/xurFVzKQglMARweYRWM6Hw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "2.0.0",
+        "diff": "3.5.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.3.2",
+        "nise": "1.3.2",
+        "supports-color": "5.3.0",
+        "type-detect": "4.0.8"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
     },
     "sliced": {
       "version": "1.0.1",
@@ -3431,6 +3302,12 @@
         "socket.io-parser": "2.2.2"
       },
       "dependencies": {
+        "component-emitter": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
+          "optional": true
+        },
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
@@ -3529,6 +3406,11 @@
         "json3": "3.3.2"
       },
       "dependencies": {
+        "component-emitter": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM="
+        },
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
@@ -3661,6 +3543,86 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "optional": true
     },
+    "superagent": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
+      "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1",
+        "cookiejar": "2.1.1",
+        "debug": "3.1.0",
+        "extend": "3.0.1",
+        "form-data": "2.3.2",
+        "formidable": "1.2.1",
+        "methods": "1.1.2",
+        "mime": "1.6.0",
+        "qs": "6.5.1",
+        "readable-stream": "2.0.6"
+      },
+      "dependencies": {
+        "combined-stream": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
+          }
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
+        }
+      }
+    },
+    "supertest": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-3.0.0.tgz",
+      "integrity": "sha1-jUu2j9GDDuBwM7HFpamkAhyWUpY=",
+      "dev": true,
+      "requires": {
+        "methods": "1.1.2",
+        "superagent": "3.8.2"
+      }
+    },
+    "supports-color": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "2.0.0"
+      }
+    },
     "tar": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
@@ -3695,11 +3657,17 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "requires": {
-        "bl": "1.2.1",
+        "bl": "1.2.2",
         "end-of-stream": "1.4.1",
         "readable-stream": "2.0.6",
         "xtend": "4.0.1"
       }
+    },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
     },
     "text-hex": {
       "version": "0.0.0",
@@ -3720,11 +3688,6 @@
         "xtend": "4.0.1"
       },
       "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -3749,138 +3712,12 @@
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
       "optional": true
     },
-    "to-boolean-x": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.3.tgz",
-      "integrity": "sha512-kQiMyJUgFprL8J+0CfgJuaSFKJMs3EvFe27/6aj/hVzVZT0HY4aA1QjPldLNxzBmjhLcapp7CctYHuD8QqtS3g=="
-    },
-    "to-integer-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz",
-      "integrity": "sha512-794L2Lpwjtynm7RxahJi2YdbRY75gTxUW27TMuN26UgwPkmJb/+HPhkFEFbz+E4vNoiP0dxq5tq5fkXoXLaK/w==",
-      "requires": {
-        "is-finite-x": "3.0.4",
-        "is-nan-x": "1.0.3",
-        "math-sign-x": "3.0.0",
-        "to-number-x": "2.0.0"
-      }
-    },
-    "to-number-x": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz",
-      "integrity": "sha512-lGOnCoccUoSzjZ/9Uen8TC4+VFaQcFGhTroWTv2tYWxXgyJV1zqAZ8hEIMkez/Eo790fBMOjidTnQ/OJSCvAoQ==",
-      "requires": {
-        "cached-constructors-x": "1.0.2",
-        "nan-x": "1.0.2",
-        "parse-int-x": "2.0.0",
-        "to-primitive-x": "1.1.0",
-        "trim-x": "3.0.0"
-      }
-    },
-    "to-object-x": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/to-object-x/-/to-object-x-1.5.0.tgz",
-      "integrity": "sha512-AKn5GQcdWky+s20vjWkt+Wa6y3dxQH3yQyMBhOfBOPldUwqwhgvlqcIg5H092ntNc+TX8/Cxzs1kMHH19pyCnA==",
-      "requires": {
-        "cached-constructors-x": "1.0.2",
-        "require-object-coercible-x": "1.4.3"
-      }
-    },
-    "to-primitive-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/to-primitive-x/-/to-primitive-x-1.1.0.tgz",
-      "integrity": "sha512-gyMY0gi3wjK3e4MUBKqv9Zl8QGcWguIkaUr2VJmoBEsOpDcpDZSEyljR773eVG4maS48uX7muLkoQoh/BA82OQ==",
-      "requires": {
-        "has-symbol-support-x": "1.4.2",
-        "is-date-object": "1.0.1",
-        "is-function-x": "3.3.0",
-        "is-nil-x": "1.4.2",
-        "is-primitive": "2.0.0",
-        "is-symbol": "1.0.1",
-        "require-object-coercible-x": "1.4.3",
-        "validate.io-undefined": "1.0.3"
-      },
-      "dependencies": {
-        "is-primitive": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-        }
-      }
-    },
-    "to-property-key-x": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/to-property-key-x/-/to-property-key-x-2.0.2.tgz",
-      "integrity": "sha512-YISLpZFYIazNm0P8hLsKEEUEZ3m8U3+eDysJZqTu3+B9tQp+2TrMpaEGT8Agh4fZ5LSoums60/glNEzk5ozqrg==",
-      "requires": {
-        "has-symbol-support-x": "1.4.2",
-        "to-primitive-x": "1.1.0",
-        "to-string-x": "1.4.5"
-      }
-    },
-    "to-string-symbols-supported-x": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/to-string-symbols-supported-x/-/to-string-symbols-supported-x-1.0.2.tgz",
-      "integrity": "sha512-3MRqhIhSNVDsVAk4M6WNcuBZrAQe54W13xrXX6RzxXS+pA4nj6DQ96RegQS5z9BSNyYbFsBsPvMVDIpP+a/5RA==",
-      "requires": {
-        "cached-constructors-x": "1.0.2",
-        "has-symbol-support-x": "1.4.2",
-        "is-symbol": "1.0.1"
-      }
-    },
-    "to-string-tag-x": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.4.3.tgz",
-      "integrity": "sha512-5+0EZ6dOVt/XArXmkooxPzWxmOR081HM/uXitUow7h11WYg5pPo15uYqDWuqO7ZY+O3Atn/dG26wcJCK+mFevg==",
-      "requires": {
-        "lodash.isnull": "3.0.0",
-        "validate.io-undefined": "1.0.3"
-      }
-    },
-    "to-string-x": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/to-string-x/-/to-string-x-1.4.5.tgz",
-      "integrity": "sha512-5xzlZDyDa9BUWNjNzZzHgKQ95PnV7qjvEhbqpFaj1ixaHgfJXOFaa3xdMJ+WLYd4hhaMJaxt8Pt5uKaWXfruXA==",
-      "requires": {
-        "cached-constructors-x": "1.0.2",
-        "is-symbol": "1.0.1"
-      }
-    },
     "tough-cookie": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
       "requires": {
         "punycode": "1.4.1"
-      }
-    },
-    "trim-left-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-3.0.0.tgz",
-      "integrity": "sha512-+m6cqkppI+CxQBTwWEZliOHpOBnCArGyMnS1WCLb6IRgukhTkiQu/TNEN5Lj2eM9jk8ewJsc7WxFZfmwNpRXWQ==",
-      "requires": {
-        "cached-constructors-x": "1.0.2",
-        "require-coercible-to-string-x": "1.0.2",
-        "white-space-x": "3.0.1"
-      }
-    },
-    "trim-right-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-3.0.0.tgz",
-      "integrity": "sha512-iIqEsWEbWVodqdixJHi4FoayJkUxhoL4AvSNGp4FF4FfQKRPGizt8++/RnyC9od75y7P/S6EfONoVqP+NddiKA==",
-      "requires": {
-        "cached-constructors-x": "1.0.2",
-        "require-coercible-to-string-x": "1.0.2",
-        "white-space-x": "3.0.1"
-      }
-    },
-    "trim-x": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-3.0.0.tgz",
-      "integrity": "sha512-w8s38RAUScQ6t3XqMkS75iz5ZkIYLQpVnv2lp3IuTS36JdlVzC54oe6okOf4Wz3UH4rr3XAb2xR3kR5Xei82fw==",
-      "requires": {
-        "trim-left-x": "3.0.0",
-        "trim-right-x": "3.0.0"
       }
     },
     "triple-beam": {
@@ -3908,6 +3745,12 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.15",
@@ -3986,11 +3829,6 @@
         "spdx-expression-parse": "1.0.4"
       }
     },
-    "validate.io-undefined": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/validate.io-undefined/-/validate.io-undefined-1.0.3.tgz",
-      "integrity": "sha1-fif8uzFbhB54JDQxiXZxkp4gt/Q="
-    },
     "vary": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
@@ -4031,11 +3869,6 @@
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "optional": true
-    },
-    "white-space-x": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-3.0.1.tgz",
-      "integrity": "sha512-BwMFXQNPna/4RsNPOgldVYn+FkEv+lc3wUiFzuaW6Z2DH/oSk1UrRD6SBqDgWQO4JU+aBq3PVuPD9Vz0j7mh0w=="
     },
     "wide-align": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "0.0.1",
   "author": "Justin Langston <nitsujlangston@gmail.com>",
   "main": "server.js",
+  "scripts" : {
+    "test": "mocha ./test/unit"
+  },
   "dependencies": {
     "JSONStream": "~1.3.1",
     "async": "^2.5.0",
@@ -23,6 +26,9 @@
   },
   "devDependencies": {
     "eslint-config-airbnb-base": "^12.1.0",
-    "eslint-plugin-import": "^2.8.0"
+    "eslint-plugin-import": "^2.8.0",
+    "mocha": "^5.0.5",
+    "sinon": "^4.4.8",
+    "supertest": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "body-parser": "~1.17.2",
     "express": "~4.15.3",
     "mkdirp": "^0.5.1",
-    "mongoose": "^5.0.11",
+    "mongoose": "^5.0.3",
     "progress": "^2.0.0",
     "request": "^2.81.0",
     "snappy": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "body-parser": "~1.17.2",
     "express": "~4.15.3",
     "mkdirp": "^0.5.1",
-    "mongoose": "^5.0.3",
+    "mongoose": "^5.0.11",
     "progress": "^2.0.0",
     "request": "^2.81.0",
     "snappy": "^6.0.1",

--- a/server.js
+++ b/server.js
@@ -1,12 +1,6 @@
 const async = require('async');
 const cluster = require('cluster');
 
-const express = require('express');
-const bodyParser = require('body-parser');
-const app = express();
-app.use(bodyParser.json());
-app.use(bodyParser.raw({limit: 100000000}));
-
 const logger = require('./lib/logger');
 const config = require('./lib/config');
 const storageService = require('./lib/services/storage');
@@ -28,12 +22,10 @@ async.series([
   }
 ], function () {
   if (cluster.isWorker) {
-    const router = require('./lib/routes')(app);
-    app.use('/api/:chain/:network', router);
+    const app = require('./lib/routes');
     const server = app.listen(config.port, function () {
       logger.info(`API server started on port ${config.port}`);
     });
     server.timeout = 600000;
   }
 });
-

--- a/server.js
+++ b/server.js
@@ -28,7 +28,7 @@ async.series([
   }
 ], function () {
   if (cluster.isWorker) {
-    const router = require('./lib/routes');
+    const router = require('./lib/routes')(app);
     app.use('/api', router);
     const server = app.listen(config.port, function () {
       logger.info(`API server started on port ${config.port}`);

--- a/server.js
+++ b/server.js
@@ -29,7 +29,7 @@ async.series([
 ], function () {
   if (cluster.isWorker) {
     const router = require('./lib/routes')(app);
-    app.use('/api', router);
+    app.use('/api/:chain/:network', router);
     const server = app.listen(config.port, function () {
       logger.info(`API server started on port ${config.port}`);
     });

--- a/server.js
+++ b/server.js
@@ -22,8 +22,7 @@ async.series([
   }
 ], function () {
   if (cluster.isWorker) {
-    const router = require('./lib/routes')(app);
-    app.use('/api', router);
+    const app = require('./lib/routes');
     const server = app.listen(config.port, function () {
       logger.info(`API server started on port ${config.port}`);
     });

--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ async.series([
       for (let network of Object.keys(config.chains[chain])){
         const chainConfig = config.chains[chain][network];
         const hasChainSource = chainConfig.chainSource !== undefined;
-        if(!hasChainSource || (hasChainSource && chainConfig.chainSource === 'p2p')) {
+        if(!hasChainSource || chainConfig.chainSource === 'p2p') {
           let p2pServiceConfig = Object.assign(config.chains[chain][network], {chain,network});
           p2pServices.push(new p2pService(p2pServiceConfig));
         }

--- a/server.js
+++ b/server.js
@@ -14,7 +14,9 @@ async.series([
     let p2pServices = [];
     for (let chain of Object.keys(config.chains)){
       for (let network of Object.keys(config.chains[chain])){
-        if(!config.chains[chain].nosync) {
+        const chainConfig = config.chains[chain][network];
+        const hasChainSource = chainConfig.chainSource !== undefined;
+        if(!hasChainSource || (hasChainSource && chainConfig.chainSource === 'p2p')) {
           let p2pServiceConfig = Object.assign(config.chains[chain][network], {chain,network});
           p2pServices.push(new p2pService(p2pServiceConfig));
         }

--- a/server.js
+++ b/server.js
@@ -14,8 +14,10 @@ async.series([
     let p2pServices = [];
     for (let chain of Object.keys(config.chains)){
       for (let network of Object.keys(config.chains[chain])){
-        let p2pServiceConfig = Object.assign(config.chains[chain][network], {chain,network});
-        p2pServices.push(new p2pService(p2pServiceConfig));
+        if(!config.chains[chain].nosync) {
+          let p2pServiceConfig = Object.assign(config.chains[chain][network], {chain,network});
+          p2pServices.push(new p2pService(p2pServiceConfig));
+        }
       }
     }
     await Promise.all(p2pServices.map(p2pService => p2pService.start()));

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -1,0 +1,2 @@
+const StorageService = require('../../lib/services/storage');
+StorageService.start(() => {}, {dbName: 'bitcore-test'});

--- a/test/unit/address.unit.js
+++ b/test/unit/address.unit.js
@@ -1,0 +1,23 @@
+const request = require('supertest')('http://localhost:3000');
+
+const UTXO = {
+  txid: '27e2e260f7f709007997127a1d2a9d05954e5024e6ad0ddec3fddfa2e9b7d36f',
+  vout: 1,
+  address: 'mhjTB1BvPsaWUKX3baWk551Hdi5Cf51vsQ',
+  script: '76a914184d5980f9a638c191f1a9c02114673e687dbdbc88ac',
+  value: 250000
+};
+
+describe('Address API', () => {
+  const TESTNET_ADDR = 'mhjTB1BvPsaWUKX3baWk551Hdi5Cf51vsQ';
+  it('should be able to stream address UTXOs', (done) => {
+    request
+      .get(`/api/BTC/testnet/address/${TESTNET_ADDR}`)
+      .expect(200, [UTXO], done);
+  });
+  it('should be able to get address balance', (done) => {
+    request
+      .get(`/api/BTC/testnet/address/${TESTNET_ADDR}/balance`)
+      .expect(200, {balance: UTXO.value},  done);
+  });
+});

--- a/test/unit/addresses.jsonl
+++ b/test/unit/addresses.jsonl
@@ -1,0 +1,1 @@
+{"address":"mhjTB1BvPsaWUKX3baWk551Hdi5Cf51vsQ"}

--- a/test/unit/addresses.jsonl
+++ b/test/unit/addresses.jsonl
@@ -1,1 +1,0 @@
-{"address":"mhjTB1BvPsaWUKX3baWk551Hdi5Cf51vsQ"}

--- a/test/unit/block.unit.js
+++ b/test/unit/block.unit.js
@@ -1,0 +1,14 @@
+const request = require('supertest')('http://localhost:3000');
+const assert = require('assert');
+
+describe('Block API', () => {
+  const BLOCK_NUM = 1;
+  it('should be able to get the first block', (done) => {
+    request
+      .get(`/api/BTC/testnet/block/${BLOCK_NUM}`)
+      .expect(200, (err, { body })=> {
+        assert.equal(body.height, 1);
+        done();
+      });
+  });
+});

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,0 +1,4 @@
+require('./address.unit');
+require('./block.unit');
+require('./tx.unit');
+require('./wallet.unit');

--- a/test/unit/mock.js
+++ b/test/unit/mock.js
@@ -1,0 +1,21 @@
+var mongoose = require('mongoose');
+
+mongoose.Collection.prototype._insert = mongoose.Collection.prototype.insert;
+// this method is propagated from node-mongodb-native
+mongoose.Collection.prototype.insert = function(docs, options, callback) {
+  // this is what the API would do if the save succeeds!
+  callback(null, docs);
+};
+
+mongoose.mock = function() {
+  mongoose.Collection.prototype.insert = function(docs, options, callback) {
+    // this is what the API would do if the save succeeds!
+    callback(null, docs);
+  };
+};
+
+mongoose.unmock = function() {
+  mongoose.Collection.prototype.insert = mongoose.Collection.prototype._insert;
+};
+
+module.exports = mongoose;

--- a/test/unit/tx.unit.js
+++ b/test/unit/tx.unit.js
@@ -1,0 +1,14 @@
+const request = require('supertest')('http://localhost:3000');
+const assert = require('assert');
+
+describe('TX Api', () => {
+  const TXID = '27e2e260f7f709007997127a1d2a9d05954e5024e6ad0ddec3fddfa2e9b7d36f';
+  it('should be able to get the Transaction', (done) => {
+    request
+      .get(`/api/BTC/testnet/tx/${TXID}`)
+      .expect(200, (err, { text }) => {
+        assert.equal(text.includes(TXID), true);
+        done();
+      });
+  });
+});

--- a/test/unit/wallet.unit.js
+++ b/test/unit/wallet.unit.js
@@ -1,0 +1,51 @@
+const mongoose = require('./mock');
+const app = require('../../lib/routes');
+const sinon = require('sinon');
+const request = require('supertest')(app);
+const assert = require('assert');
+const Wallet = mongoose.model('Wallet');
+
+const WALLET = {
+  chain: 'BTC',
+  network: 'testnet',
+  name: '{"iv":"68SeMjqIStpc791Z05drcg==","v":1,"iter":1,"ks":128,"ts":64,"mode":"ccm","adata":"","cipher":"aes","ct":"KfMGLa/+AlDpGNFr7Yer1ovE"}',
+  pubKey: '03bdb94afdc7e5c4811bf9b160ac475b92156ea42c8659c8358b68c828df9a1c3d',
+  path: 'm/44\'/0\'/0\''
+};
+
+beforeEach(() => {
+  sinon.stub(Wallet, 'findOne').returns({
+    exec: sinon.stub().returns(Promise.resolve(WALLET))
+  });
+});
+
+afterEach(() => {
+  Wallet.findOne.restore();
+});
+describe('Wallet Api', () => {
+  it('should be able to create a wallet', (done) => {
+    request
+      .post('/api/BTC/testnet/wallet')
+      .send(WALLET)
+      .expect(200, (err, {
+        body
+      }) => {
+        assert.equal(
+          body.pubKey,
+          WALLET.pubKey,
+          'The wallet should be created with the passed in pubKey');
+        done();
+      });
+  });
+
+  it('should be able to find a wallet', (done) => {
+    request
+      .get('/api/BTC/testnet/wallet/somefakewalletid')
+      .expect(200, (err, {
+        text
+      }) => {
+        assert.equal(text.includes(WALLET.pubKey), true, 'The wallet should be found');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
# Api
Rest api should be generalized like below
```
router.use('api/:chain/:network/wallet/:walletId/balance', () => {
  let balance = await ChainStateProvider.getBalanceForWallet(chain, network, walletId);
  res.send({balance});
});
```

# Chain State Provider
- Each chain would implement this interface, then the REST api will function for that chain
- Bitcoin based coins can inherit the BTCStateProvider
- Should lower the barrier to adding new coins to the wallet

# Tests
Still have a lot of work left to do here but partial coverage for the following	
- Coverage for address endpoints
- Coverage for block endpoints
- Coverage for transaction endpoints
